### PR TITLE
beta3

### DIFF
--- a/cheat_codes.lua
+++ b/cheat_codes.lua
@@ -690,6 +690,7 @@ function init()
   rec.end_point = 9
   rec.loop = 1
   rec.clear = 0
+  rec.rate_offset = 1.0
   
   params:add_separator("cheat codes params")
   
@@ -854,8 +855,9 @@ function init()
   
   page = {}
   page.main_sel = 1
-  page.loops_sel = 0
+  page.loops_sel = 1
   page.loops_page = 0
+  page.loops_view = {1,1,1,1}
   page.levels_sel = 0
   page.panning_sel = 1
   page.filtering_sel = 0
@@ -2376,6 +2378,7 @@ function buff_flush()
 end
 
 function toggle_buffer(i)
+  grid_dirty = true
   softcut.level_slew_time(1,0.5)
   softcut.fade_time(1,0.01)
   
@@ -2493,11 +2496,33 @@ function key(n,z)
       end
     elseif menu == 2 then
       if not key1_hold then
-        local loop_nav = (page.loops_sel + 1)%4
-        page.loops_sel = loop_nav
+        page.loops_view[page.loops_sel] = (page.loops_view[page.loops_sel] % 2) + 1
       else
-        page.loops_page = (page.loops_page+1)%2
+        if page.loops_sel < 4 then
+          local id = page.loops_sel
+          bank[id][bank[id].id].loop = not bank[id][bank[id].id].loop
+          if bank[id][bank[id].id].loop then
+            softcut.loop(id+1,1)
+            softcut.position(id+1,bank[id][bank[id].id].start_point)
+          else
+            softcut.loop(id+1,0)
+          end
+          grid_dirty = true
+        elseif page.loops_sel == 4 then
+          toggle_buffer(rec.clip)
+          -- if params:get("rec_loop") == 1 then
+          --   rec.state = math.abs((rec.state % 2) - 1)
+          --   softcut.rec_level(1,rec.state)
+          -- else
+          --   softcut.position(1,rec.start_point)
+          --   rec.state = 1
+          --   softcut.rec_level(1,rec.state)
+          -- end
+
+        end
       end
+
+
     elseif menu == 3 then
       local level_nav = (page.levels_sel + 1)%3
       page.levels_sel = level_nav
@@ -2678,18 +2703,7 @@ function key(n,z)
       end
     elseif menu == 2 then
       if key1_hold then
-        if page.loops_page == 0 then
-          if page.loops_sel < 3 then
-            local id = page.loops_sel+1
-            bank[id][bank[id].id].loop = not bank[id][bank[id].id].loop
-            if bank[id][bank[id].id].loop then
-              softcut.loop(id+1,1)
-              softcut.position(id+1,bank[id][bank[id].id].start_point)
-            else
-              softcut.loop(id+1,0)
-            end
-          end
-        end
+        --
       else
         menu = 1
       end

--- a/cheat_codes.lua
+++ b/cheat_codes.lua
@@ -3594,6 +3594,7 @@ function new_arc_pattern_execute(entry)
       end
     elseif entry.param == 5 then
       bank[id][which_pad].level = (entry.level + arc_offset)
+      bank[id].global_level = (entry.global_level + arc_offset)
       if bank[id].id == which_pad then
         softcut.level(id+1, (entry.level + arc_offset)*bank[id].global_level)
       end
@@ -4923,6 +4924,7 @@ function save_arc_pattern(which)
       io.write("event "..i.." tilt: "..arc_pat[which][j].event[i].tilt .. "\n")
       io.write("event "..i.." pan: "..arc_pat[which][j].event[i].pan .. "\n")
       io.write("event "..i.." level: "..arc_pat[which][j].event[i].level .. "\n")
+      io.write("event "..i.." global level: "..arc_pat[which][j].event[i].global_level .. "\n")
     end
     io.write("recording "..j.." props time: "..arc_pat[which][j].metro.props.time .. "\n")
     io.write("recording "..j.." prev time: "..arc_pat[which][j].prev_time .. "\n")
@@ -4954,6 +4956,7 @@ function load_arc_pattern(which)
           arc_pat[which][j].event[i].tilt = {}
           arc_pat[which][j].event[i].pan = {}
           arc_pat[which][j].event[i].level = {}
+          arc_pat[which][j].event[i].global_level = {}
           --
           arc_pat[which][j].event[i].i1 = tonumber(string.match(io.read(), ': (.*)'))
           arc_pat[which][j].event[i].i2 = tonumber(string.match(io.read(), ': (.*)'))
@@ -4965,6 +4968,7 @@ function load_arc_pattern(which)
           arc_pat[which][j].event[i].tilt = tonumber(string.match(io.read(), ': (.*)'))
           arc_pat[which][j].event[i].pan = tonumber(string.match(io.read(), ': (.*)'))
           arc_pat[which][j].event[i].level = tonumber(string.match(io.read(), ': (.*)'))
+          arc_pat[which][j].event[i].global_level = tonumber(string.match(io.read(), ': (.*)'))
         end
         arc_pat[which][j].metro.props.time = tonumber(string.match(io.read(), ': (.*)'))
         arc_pat[which][j].prev_time = tonumber(string.match(io.read(), ': (.*)'))

--- a/cheat_codes.lua
+++ b/cheat_codes.lua
@@ -48,6 +48,7 @@ arc_control = {}
 for i = 1,3 do
   arc_control[i] = i
 end
+arc_meta_focus = 1
 
 arc_offset = 0 --IMPORTANT TO REVISIT
 
@@ -472,12 +473,12 @@ end
 
 function save_external_timing(bank,slot)
   
-  local dirname = _path.data.."cheat_codes/external-timing/"
+  local dirname = _path.data.."cheat_codes2/external-timing/"
   if os.rename(dirname, dirname) == nil then
     os.execute("mkdir " .. dirname)
   end
   
-  local file = io.open(_path.data .. "cheat_codes/external-timing/pattern"..selected_coll.."_"..slot.."_external-timing.data", "w+")
+  local file = io.open(_path.data .. "cheat_codes2/external-timing/pattern"..selected_coll.."_"..slot.."_external-timing.data", "w+")
   io.output(file)
   io.write("external clock timing for stored pad pattern: collection "..selected_coll.." + slot "..slot.."\n")
   local total_entry_count = 0
@@ -499,7 +500,7 @@ function save_external_timing(bank,slot)
 end
 
 function load_external_timing(bank,slot)
-  local file = io.open(_path.data .. "cheat_codes/external-timing/pattern"..selected_coll.."_"..slot.."_external-timing.data", "r")
+  local file = io.open(_path.data .. "cheat_codes2/external-timing/pattern"..selected_coll.."_"..slot.."_external-timing.data", "r")
   if file then
     io.input(file)
     if io.read() == "external clock timing for stored pad pattern: collection "..selected_coll.." + slot "..slot then
@@ -1239,6 +1240,13 @@ function init()
     end
     , 1/30, -1)
   hardware_redraw:start()
+
+  -- for i = 0,100 do
+  --   local dirname = _path.data.."cheat_codes2/collection-"..i
+  --   if os.rename(dirname, dirname) == nil then
+  --     os.execute("mkdir " .. dirname)
+  --   end
+  -- end
 
 end
 
@@ -2519,27 +2527,27 @@ function load_sample(file,sample)
 end
 
 function save_sample(i)
-  local dirname = _path.dust.."audio/cc_saved_samples/"
+  local dirname = _path.dust.."audio/cc2_saved_samples/"
   if os.rename(dirname, dirname) == nil then
     os.execute("mkdir " .. dirname)
   end
-  local name = "cc_"..os.date("%y%m%d_%X-buff")..i..".wav"
+  local name = "cc2_"..os.date("%y%m%d_%X-buff")..i..".wav"
   local save_pos = i - 1
-  softcut.buffer_write_mono(_path.dust.."/audio/cc_saved_samples/"..name,1+(8*save_pos),8,1)
+  softcut.buffer_write_mono(_path.dust.."/audio/cc2_saved_samples/"..name,1+(8*save_pos),8,1)
 end
 
 function collect_samples(i) -- this works!!!
-  local dirname = _path.dust.."audio/cc_collection-samples/"
+  local dirname = _path.dust.."audio/cc2_live-audio/"
   if os.rename(dirname, dirname) == nil then
     os.execute("mkdir " .. dirname)
   end
-  local dirname = _path.dust.."audio/cc_collection-samples/"..params:get("collection").."/"
+  local dirname = _path.dust.."audio/cc2_live-audio/"..params:get("collection").."/"
   if os.rename(dirname, dirname) == nil then
     os.execute("mkdir " .. dirname)
   end
-  local name = "cc_"..params:get("collection").."-"..i..".wav"
+  local name = "cc2_"..params:get("collection").."-"..i..".wav"
   local save_pos = i - 1
-  softcut.buffer_write_mono(_path.dust.."audio/cc_collection-samples/"..params:get("collection").."/"..name,1+(8*save_pos),8,1)
+  softcut.buffer_write_mono(_path.dust.."audio/cc2_live-audio/"..params:get("collection").."/"..name,1+(8*save_pos),8,1)
 end
 
 function reload_collected_samples(file,sample)
@@ -2548,6 +2556,7 @@ function reload_collected_samples(file,sample)
   end
   if file ~= "-" then
     softcut.buffer_read_mono(file, 0, 1+(8 * (sample-1)), 8, 1, 1)
+    print("reloaded previous session's audio")
   end
 end
 
@@ -3717,24 +3726,30 @@ arc_redraw = function()
     end
   end
   
-  for i = 1,13 do
-    local arc_left_delay_level = (params:get("delay L: div/mult") == i and 15 or 5)
-    local arc_right_delay_level = (params:get("delay R: div/mult") == i and 15 or 5)
-    local arc_try = params:get("delay L: div/mult")
-    if arc.alt == nil or arc.alt == 0 then
-      a:led(4,(41+((i-1)*4)-16),arc_left_delay_level)
-    else
-      a:led(4,(41+((i-1)*4)-16),arc_right_delay_level)
-    end
+  -- for i = 1,13 do
+  --   local arc_left_delay_level = (params:get("delay L: div/mult") == i and 15 or 5)
+  --   local arc_right_delay_level = (params:get("delay R: div/mult") == i and 15 or 5)
+  --   local arc_try = params:get("delay L: div/mult")
+  --   if arc.alt == nil or arc.alt == 0 then
+  --     a:led(4,(41+((i-1)*4)-16),arc_left_delay_level)
+  --   else
+  --     a:led(4,(41+((i-1)*4)-16),arc_right_delay_level)
+  --   end
+  -- end
+
+  arc_meta_level = {}
+  for i = 1,6 do
+    arc_meta_level[i] = util.round(arc_meta_focus) == i and 15 or 5
+    a:led(4,((i-1)*8)+25,arc_meta_level[i])
   end
-  
+
   a:refresh()
 end
 
 --file loading
 
 function persistent_state_save()
-  local file = io.open(_path.data.. "cheat_codes/persistent_state.data", "w+")
+  local file = io.open(_path.data.. "cheat_codes2/persistent_state.data", "w+")
   io.output(file)
   io.write("midi_control_enabled: "..params:get("midi_control_enabled").."\n")
   io.write("midi_control_device: "..params:get("midi_control_device").."\n")
@@ -3757,10 +3772,10 @@ function count_lines_in(file)
 end
 
 function persistent_state_restore()
-  local file = io.open(_path.data .. "cheat_codes/persistent_state.data", "r")
+  local file = io.open(_path.data .. "cheat_codes2/persistent_state.data", "r")
   if file then
     io.input(file)
-    for i = 1,count_lines_in(_path.data.. "cheat_codes/persistent_state.data") do
+    for i = 1,count_lines_in(_path.data.. "cheat_codes2/persistent_state.data") do
       local s = io.read()
       local param,val = s:match("(.+): (.+)")
       params:set(param,tonumber(val))
@@ -3769,10 +3784,10 @@ function persistent_state_restore()
   end
 end
 
-function testsavestate()
+function savestate()
   
   local dirname = _path.data.."cheat_codes2/"
-  local collection = params:get("collection")
+  local collection = tonumber(string.format("%.0f",params:get("collection")))
   if os.rename(dirname, dirname) == nil then
     os.execute("mkdir " .. dirname)
   end
@@ -3782,9 +3797,8 @@ function testsavestate()
     os.execute("mkdir " .. dirname)
   end
 
-  local dirnames = {"banks/","params/","arc-pat/","grid-pat/","step-seq/","arps/","euclid/","rnd/","delays/"}
+  local dirnames = {"banks/","params/","arc-rec/","patterns/","step-seq/","arps/","euclid/","rnd/","delays/","rec/"}
   for i = 1,#dirnames do
-    -- print(_path.data.."cheat_codes2/collection-"..collection.."/"..dirnames[i])
     local directory = _path.data.."cheat_codes2/collection-"..collection.."/"..dirnames[i]
     if os.rename(directory, directory) == nil then
       os.execute("mkdir " .. directory)
@@ -3793,41 +3807,75 @@ function testsavestate()
 
   for i = 1,3 do
     tab.save(bank[i],_path.data .. "cheat_codes2/collection-"..collection.."/banks/"..i..".data")
-    tab.save(arc_pat[i],_path.data .. "cheat_codes2/collection-"..collection.."/arc-pat/"..i..".data")
     tab.save(step_seq[i],_path.data .. "cheat_codes2/collection-"..collection.."/step-seq/"..i..".data")
-    -- tab.save(grid_pat[i],_path.data .. "cheat_codes2/collection-"..collection.."/grid-pat/"..i..".data")
     tab.save(arp[i],_path.data .. "cheat_codes2/collection-"..collection.."/arps/"..i..".data")
     tab.save(rytm.track[i],_path.data .. "cheat_codes2/collection-"..collection.."/euclid/euclid"..i..".data")
+    tab.save(rnd[i],_path.data .. "cheat_codes2/collection-"..collection.."/rnd/"..i..".data")
+    if params:get("collect_live") == 2 then
+      collect_samples(i)
+    end
   end
+
   for i = 1,2 do
     tab.save(delay[i],_path.data .. "cheat_codes2/collection-"..collection.."/delays/delay"..(i == 1 and "L" or "R")..".data")
   end
+  
   params:write(_path.data.."cheat_codes2/collection-"..collection.."/params/all.pset")
+  tab.save(rec,_path.data .. "cheat_codes2/collection-"..collection.."/rec/rec.data")
 
-  for i = 1,3 do
-    tab.save(rnd[i],_path.data .. "cheat_codes2/collection-"..collection.."/rnd/"..i..".data")
+  -- GRID pattern save
+  if selected_coll ~= collection then
+    meta_copy_coll(selected_coll,collection)
   end
+  meta_shadow(collection)
+  selected_coll = collection
+  --/ GRID pattern save
+
+  -- MIDI pattern save
+  for i = 1,3 do
+    save_midi_pattern(i)
+  end
+  --/ MIDI pattern save
+
+  -- ARC rec save
+  local arc_rec_dirty = {false,false,false}
+  for i = 1,3 do
+    for j = 1,4 do
+      if arc_pat[i][j].count > 0 then
+        arc_rec_dirty[i] = true
+      end
+    end
+    if arc_rec_dirty[i] then
+      save_arc_pattern(i)
+    else
+      local file = io.open(_path.data .. "cheat_codes2/collection-"..selected_coll.."/arc-rec/encoder-"..i..".data", "r")
+      if file then
+        io.input(file)
+        os.remove(_path.data .. "cheat_codes2/collection-"..selected_coll.."/arc-rec/encoder-"..i..".data")
+        io.close(file)
+      end
+    end
+  end
+  --/ ARC rec save
 
 end
 
 
-function testloadstate()
-  local collection = params:get("collection")
+function loadstate()
+  local collection = tonumber(string.format("%.0f",params:get("collection")))
+  selected_coll = collection
   params:read(_path.data.."cheat_codes2/collection-"..collection.."/params/all.pset")
+  if tab.load(_path.data .. "cheat_codes2/collection-"..collection.."/rec/rec.data") ~= nil then
+    rec = tab.load(_path.data .. "cheat_codes2/collection-"..collection.."/rec/rec.data")
+  end
   -- params:bang()
   for i = 1,3 do
     if tab.load(_path.data .. "cheat_codes2/collection-"..collection.."/banks/"..i..".data") ~= nil then
       bank[i] = tab.load(_path.data .. "cheat_codes2/collection-"..collection.."/banks/"..i..".data")
     end
-    -- if tab.load(_path.data .. "cheat_codes2/collection-"..collection.."/arc-pat/"..i..".data") ~= nil then
-    --   arc_pat[i] = tab.load(_path.data .. "cheat_codes2/collection-"..collection.."/arc-pat/"..i..".data")
-    -- end
     if tab.load(_path.data .. "cheat_codes2/collection-"..collection.."/step-seq/"..i..".data") ~= nil then
       step_seq[i] = tab.load(_path.data .. "cheat_codes2/collection-"..collection.."/step-seq/"..i..".data")
     end
-    -- if tab.load(_path.data .. "cheat_codes2/collection-"..collection.."/grid-pat/"..i..".data") ~= nil then
-    --   grid_pat[i] = tab.load(_path.data .. "cheat_codes2/collection-"..collection.."/grid-pat/"..i..".data")
-    -- end
     if tab.load(_path.data .. "cheat_codes2/collection-"..collection.."/arps/"..i..".data") ~= nil then
       arp[i] = tab.load(_path.data .. "cheat_codes2/collection-"..collection.."/arps/"..i..".data")
     end
@@ -3840,6 +3888,11 @@ function testloadstate()
         end
       end
     end
+
+    if params:get("collect_live") == 2 then
+      reload_collected_samples(_path.dust.."audio/cc2_live-audio/"..collection.."/".."cc2_"..collection.."-"..i..".wav",i)
+    end
+    
     if tab.load(_path.data .. "cheat_codes2/collection-"..collection.."/euclid/euclid"..i..".data") ~= nil then
       rytm.track[i] = tab.load(_path.data .. "cheat_codes2/collection-"..collection.."/euclid/euclid"..i..".data")
     end
@@ -3852,456 +3905,477 @@ function testloadstate()
     end
   end
 
-  grid_dirty = true
-
-end
-
-function savestate()
-  local file = io.open(_path.data .. "cheat_codes/collections"..tonumber(string.format("%.0f",params:get("collection")))..".data", "w+")
-  io.output(file)
-  io.write("PERMANENCE".."\n")
-  for i = 1,3 do
-    for k = 1,16 do 
-      io.write(bank[i].id .. "\n")
-      io.write(selected[i].x .. "\n")
-      io.write(selected[i].y .. "\n")
-      io.write(bank[i][k].clip .. "\n")
-      io.write(bank[i][k].mode .. "\n")
-      io.write(bank[i][k].start_point .. "\n")
-      io.write(bank[i][k].end_point .. "\n")
-      io.write(bank[i][k].rate .. "\n")
-      io.write(tostring(bank[i][k].pause) .. "\n")
-      io.write(tostring(bank[i][k].play_mode) .. "\n")
-      io.write(bank[i][k].level .. "\n")
-      io.write(tostring(bank[i][k].loop) .. "\n")
-      io.write(tostring(bank[i][k].fifth) .. "\n")
-      io.write(bank[i][k].pan .. "\n")
-      io.write(bank[i][k].fc .. "\n")
-      io.write(bank[i][k].q .. "\n")
-      io.write(bank[i][k].lp .. "\n")
-      io.write(bank[i][k].hp .. "\n")
-      io.write(bank[i][k].bp .. "\n")
-      io.write(bank[i][k].fd .. "\n")
-      io.write(bank[i][k].br .. "\n")
-      io.write(bank[i][k].filter_type .. "\n")
-      io.write(arc_control[i] .. "\n")
-      io.write(arc_param[i] .. "\n")
-    end
-    io.write(params:get("rate slew time ".. i) .. "\n")
-    io.write(tostring(params:get("clip "..i.." sample") .. "\n"))
-    local sides = {"delay L: ", "delay R: "}
-    for k = 1,2 do
-      io.write(params:get(sides[k].."div/mult") .. "\n")
-      io.write(params:get(sides[k].."global level") .. "\n")
-      io.write(params:get(sides[k].."feedback") .. "\n")
-      io.write(params:get(sides[k].."(a) send") .. "\n")
-      io.write(params:get(sides[k].."(b) send") .. "\n")
-      io.write(params:get(sides[k].."(c) send") .. "\n")
-      io.write(params:get(sides[k].."filter cut") .. "\n")
-      io.write(params:get(sides[k].."filter q") .. "\n")
-      io.write(params:get(sides[k].."filter lp") .. "\n")
-      io.write(params:get(sides[k].."filter hp") .. "\n")
-      io.write(params:get(sides[k].."filter bp") .. "\n")
-      io.write(params:get(sides[k].."filter dry") .. "\n")
-    end
-  end
-  io.write(params:get("offset").."\n")
-    -- v1.1 items
-  io.write("v1.1".."\n")
-  for i = 1,3 do
-    for k = 1,16 do
-      io.write(tostring(bank[i][k].enveloped) .. "\n")
-      io.write(bank[i][k].envelope_time .. "\n")
-    end
-  end
-  io.write(params:get("zilchmo_patterning") .. "\n")
-  io.write(params:get("rec_loop") .. "\n")
-  io.write(params:get("live_rec_feedback") .. "\n")
-  io.write(params:get("quantize_pads") .. "\n")
-  io.write(params:get("quantize_pats") .. "\n")
-  io.write(params:get("quant_div") .. "\n")
-  io.write(params:get("quant_div_pats") .. "\n")
-  io.write(params:get("bpm") .. "\n")
-  io.write(rec.clip .. "\n")
-  io.write(rec.start_point .. "\n")
-  io.write(rec.end_point .. "\n")
-  io.write("v1.1.1.1.1.1.1.1".."\n")
-  for i = 1,3 do
-    io.write(step_seq[i].active .. "\n")
-    io.write(step_seq[i].meta_duration .. "\n")
-    for k = 1,16 do
-      io.write(step_seq[i][k].meta_meta_duration .. "\n")
-      io.write(step_seq[i][k].assigned_to .. "\n")
-      io.write(bank[i][k].tilt .. "\n")
-      io.write(bank[i][k].tilt_ease_time .. "\n")
-      io.write(bank[i][k].tilt_ease_type .. "\n")
-    end
-  end
-  io.write("the last params".."\n")
-  --io.write(params:get("clock_out") .. "\n")
-  io.write("0".."\n")
-  --io.write(params:get("crow_clock_out") .. "\n")
-  io.write("0".."\n")
-  --io.write(params:get("midi_device") .. "\n")
-  io.write("0".."\n")
-  io.write(params:get("loop_enc_resolution") .."\n")
-  --io.write(params:get("clock") .. "\n")
-  io.write("0".."\n")
-  io.write(params:get("lock_pat") .. "\n")
-  for i = 1,3 do
-    io.write(bank[i].crow_execute .. "\n")
-    io.write(bank[i].snap_to_bars .. "\n")
-  end
-  for i = 1,3 do
-    for j = 1,16 do
-      io.write(bank[i][j].offset .. "\n")
-    end
-  end
-  io.write("crow execute count".."\n")
-  for i = 1,3 do
-    io.write(crow.count_execute[i] .. "\n")
-  end
-  io.write("step seq loop points".."\n")
-  for i = 1,3 do
-    io.write(step_seq[i].start_point .. "\n")
-    io.write(step_seq[i].end_point .. "\n")
-  end
-  io.write("Live buffer max".."\n")
-  io.write(params:get"live_buff_rate" .. "\n")
-  io.write("loop Pattern per step".."\n")
-  for i = 1,3 do
-    for k = 1,16 do
-      io.write(step_seq[i][k].loop_pattern.."\n")
-    end
-  end
-  io.write("collect live?".."\n")
-  io.write(params:get("collect_live").."\n")
-  if params:get("collect_live") == 2 then
-    io.write("sample refs".."\n")
-    for i = 1,3 do
-      io.write("/home/we/dust/audio/cc_collection-samples/"..params:get("collection").."/".."cc_"..params:get("collection").."-"..i..".wav".."\n")
-      collect_samples(i)
-    end
-  end
-  io.write("last Pattern playmode".."\n")
-  for i = 1,3 do
-    io.write(grid_pat[i].playmode.."\n")
-  end
-  io.write("1.2.1: arc patterning".."\n")
-  io.write(params:get("arc_patterning").."\n")
-  io.write("1.2.2: crow_pad_execute".."\n")
-  for i = 1,3 do
-    for k = 1,16 do
-      io.write(bank[i][k].crow_pad_execute.."\n")
-    end
-  end
-  io.write("1.3: Pattern random pitch range".."\n")
-  for i = 1,3 do
-    io.write(grid_pat[i].random_pitch_range.."\n")
-  end
-  io.write("1.3.1".."\n")
-  io.write("one_shot_clock_div: "..params:get("one_shot_clock_div").."\n")
-  io.write("rec_loop_enc_resolution: "..params:get("rec_loop_enc_resolution").."\n")
-  io.write("more 1.3.1".."\n")
-  io.write("random_rec_clock_prob: "..params:get("random_rec_clock_prob").."\n")
-
-  io.write("cc2.0".."\n")
-
-  io.close(file)
-  if selected_coll ~= params:get("collection") then
-    meta_copy_coll(selected_coll,params:get("collection"))
-  end
-  meta_shadow(params:get("collection"))
-  --maybe not this? want to clean up
-  selected_coll = params:get("collection")
-  for i = 1,3 do
-    if arc_pat[i][1].count > 0 then
-      save_arc_pattern(i)
-    end
-    save_midi_pattern(i)
-  end
-  for i = 1,2 do
-    del.savestate(i,selected_coll)
-  end
-  rnd.savestate()
-  arps.savestate()
-  rytm.savestate()
-end
-
-function loadstate()
-  selected_coll = params:get("collection")
-  local file = io.open(_path.data .. "cheat_codes/collections"..selected_coll..".data", "r")
-  if file then
-    io.input(file)
-    pre_cc2_sample = { false, false, false }
-    restored_clip_file = {"","",""}
-    if io.read() == "PERMANENCE" then
-      for i = 1,3 do
-        for k = 1,16 do
-          bank[i].id = tonumber(io.read())
-          selected[i].x = tonumber(io.read())
-          selected[i].y = tonumber(io.read())
-          bank[i][k].clip = tonumber(io.read())
-          bank[i][k].mode = tonumber(io.read())
-          bank[i][k].start_point = tonumber(io.read())
-          bank[i][k].end_point = tonumber(io.read())
-          bank[i][k].rate = tonumber(io.read())
-          local pause_to_boolean = io.read()
-          if pause_to_boolean == "true" then
-            bank[i][k].pause = true
-          else
-            bank[i][k].pause = false
-          end
-          bank[i][k].play_mode = io.read()
-          bank[i][k].level = tonumber(io.read())
-          local loop_to_boolean = io.read()
-          if loop_to_boolean == "true" then
-            bank[i][k].loop = true
-          else
-            bank[i][k].loop = false
-          end
-          local fifth_to_boolean = io.read()
-          if fifth_to_boolean == "true" then
-            bank[i][k].fifth = true
-          else
-            bank[i][k].fifth = false
-          end
-          bank[i][k].pan = tonumber(io.read())
-          bank[i][k].fc = tonumber(io.read())
-          bank[i][k].q = tonumber(io.read())
-          bank[i][k].lp = tonumber(io.read())
-          bank[i][k].hp = tonumber(io.read())
-          bank[i][k].bp = tonumber(io.read())
-          bank[i][k].fd = tonumber(io.read())
-          bank[i][k].br = tonumber(io.read())
-          tonumber(io.read())
-          bank[i][k].filter_type = 4
-          arc_control[i] = tonumber(io.read())
-          arc_param[i] = tonumber(io.read())
-        end
-      params:set("rate slew time ".. i,tonumber(io.read()))
-      local string_to_sample = io.read()
-      restored_clip_file[i] = string_to_sample
-      -- params:set("clip "..i.." sample", string_to_sample)
-      local sides = {"delay L: ", "delay R: "}
-      for k = 1,2 do
-        params:set(sides[k].."div/mult",tonumber(io.read()))
-        params:set(sides[k].."global level",tonumber(io.read()))
-        params:set(sides[k].."feedback",tonumber(io.read()))
-        params:set(sides[k].."(a) send",tonumber(io.read()))
-        params:set(sides[k].."(b) send",tonumber(io.read()))
-        params:set(sides[k].."(c) send",tonumber(io.read()))
-        params:set(sides[k].."filter cut",tonumber(io.read()))
-        params:set(sides[k].."filter q",tonumber(io.read()))
-        params:set(sides[k].."filter lp",tonumber(io.read()))
-        params:set(sides[k].."filter hp",tonumber(io.read()))
-        params:set(sides[k].."filter bp",tonumber(io.read()))
-        params:set(sides[k].."filter dry",tonumber(io.read()))
-      end
-    end
-    params:set("offset",tonumber(io.read()))
-    else
-      print("invalid data file")
-    end
-    if io.read() == "v1.1" then
-      for i = 1,3 do
-        for k = 1,16 do
-          local enveloped_to_boolean = io.read()
-          if enveloped_to_boolean == "true" then
-            bank[i][k].enveloped = true
-          else
-            bank[i][k].enveloped = false
-          end
-          bank[i][k].envelope_time = tonumber(io.read())
-        end
-      end
-      params:set("zilchmo_patterning",tonumber(io.read()))
-      params:set("rec_loop",tonumber(io.read()))
-      params:set("live_rec_feedback",tonumber(io.read()))
-      tonumber(io.read()) -- kill off quantize_pads
-      params:set("quantize_pads",1)
-      tonumber(io.read()) -- kill off quantize_pats
-      params:set("quantize_pats",1)
-      tonumber(io.read()) -- kill off quant_div
-      params:set("quant_div",4)
-      params:set("quant_div_pats",tonumber(io.read()))
-      local bpm_to_clock = tonumber(io.read())
-      params:set("bpm",bpm_to_clock)
-      params:set("clock_tempo",bpm_to_clock)
-      rec.clip = tonumber(io.read())
-      rec.start_point = tonumber(io.read())
-      rec.end_point = tonumber(io.read())
-      softcut.loop_start(1,rec.start_point)
-      softcut.loop_end(1,rec.end_point-0.01)
-      softcut.position(1,rec.start_point)
-    end
-    if io.read() == "v1.1.1.1.1.1.1.1" then
-      for i = 1,3 do
-        step_seq[i].active = tonumber(io.read())
-        step_seq[i].meta_duration = tonumber(io.read())
-        for k = 1,16 do
-          step_seq[i][k].meta_meta_duration = tonumber(io.read())
-          step_seq[i][k].assigned_to = tonumber(io.read())
-          bank[i][k].tilt = tonumber(io.read())
-          bank[i][k].tilt_ease_time = tonumber(io.read())
-          bank[i][k].tilt_ease_type = tonumber(io.read())
-        end
-      end
-    end
-    if io.read() == "the last params" then
-      --params:set("clock_out",tonumber(io.read()))
-      local disregard = tonumber(io.read())
-      --params:set("crow_clock_out",tonumber(io.read()))
-      local disregard = tonumber(io.read())
-      --params:set("midi_device",tonumber(io.read()))
-      local disregard = tonumber(io.read())
-      params:set("loop_enc_resolution",tonumber(io.read()))
-      --params:set("clock",tonumber(io.read()))
-      local disregard_the_clock_source = tonumber(io.read())
-      local disregard = tonumber(io.read())
-      params:set("lock_pat",1)
-      for i = 1,3 do
-        bank[i].crow_execute = tonumber(io.read())
-        bank[i].snap_to_bars = tonumber(io.read())
-      end
-      for i = 1,3 do
-        for j = 1,16 do
-          bank[i][j].offset = tonumber(io.read())
-        end
-      end
-    end
-    if io.read() == "crow execute count" then
-      for i = 1,3 do
-        crow.count_execute[i] = tonumber(io.read())
-      end
-    end
-    if io.read() == "step seq loop points" then
-      for i = 1,3 do
-        step_seq[i].start_point = tonumber(io.read())
-        step_seq[i].current_step = step_seq[i].start_point
-        step_seq[i].end_point = tonumber(io.read())
-      end
-    end
-    if io.read() == "Live buffer max" then
-      params:set("live_buff_rate",tonumber(io.read()))
-    end
-    if io.read() == "loop Pattern per step" then
-      for i = 1,3 do
-        for k = 1,16 do
-          step_seq[i][k].loop_pattern = tonumber(io.read())
-        end
-      end
-    end
-    if io.read() == "collect live?" then
-      local restore_live = tonumber(io.read())
-      params:set("collect_live",restore_live)
-      if restore_live == 2 then
-        if io.read() == "sample refs" then
-          for i = 1,3 do
-            local string_to_sample = io.read()
-            reload_collected_samples(string_to_sample,i)
-          end
-        end
-      end
-    end
-    if io.read() == "last Pattern playmode" then
-      for i = 1,3 do
-        local pm = tonumber(io.read())
-        if pm == 3 or pm == 4 then
-          grid_pat[i].playmode = 2
-          params:set("pattern_"..i.."_quantization",2)
-        else
-          grid_pat[i].playmode = 1
-        end
-      end
-    end
-    if io.read() == "1.2.1: arc patterning" then
-      params:set("arc_patterning", tonumber(io.read()))
-    end
-    if io.read() == "1.2.2: crow_pad_execute" then
-      for i = 1,3 do
-        for k = 1,16 do
-          bank[i][k].crow_pad_execute = tonumber(io.read())
-        end
-      end
-    end
-    if io.read() == "1.3: Pattern random pitch range" then
-      for i  = 1,3 do
-        grid_pat[i].random_pitch_range = tonumber(io.read())
-      end
-    end
-    if io.read() == "1.3.1" then
-      params:set("one_shot_clock_div", tonumber(string.match(io.read(), ': (.*)')))
-      params:set("rec_loop_enc_resolution", tonumber(string.match(io.read(), ': (.*)')))
-    end
-    if io.read() == "more 1.3.1" then
-      params:set("random_rec_clock_prob", tonumber(string.match(io.read(), ': (.*)')))
-    end
-    if io.read() == "cc2.0" then
-      for i = 1,3 do
-        pre_cc2_sample[i] = true -- WHY
-        params:set("clip "..i.." sample", restored_clip_file[i])
-      end
-    else
-      for i = 1,3 do
-        pre_cc2_sample[i] = true
-        params:set("clip "..i.." sample", restored_clip_file[i])
-      end
-    end
-      
-    io.close(file)
-
-    rnd.loadstate()
-    arps.loadstate()
-    rytm.loadstate()
-
-    for i = 1,3 do
-      if bank[i][bank[i].id].loop == true then
-        cheat(i,bank[i].id)
-      else
-        softcut.loop(i+1, 0)
-        softcut.position(i+1,bank[i][bank[i].id].start_point)
-      end
-    end
-  end
-  already_saved()
-
-  --- unpack quantized table here?
-
-  for i = 1,3 do
-    if step_seq[i].active == 1 and step_seq[i][step_seq[i].current_step].assigned_to ~= 0 then
-      test_load(step_seq[i][step_seq[i].current_step].assigned_to+((i-1)*8),i)
-    end
-  end
-  --maybe?
-  if selected_coll ~= params:get("collection") then
-    print("not selected coll!")
+  -- GRID pattern restore
+  if selected_coll ~= collection then
     meta_shadow(selected_coll)
-  elseif selected_coll == params:get("collection") then
+  elseif selected_coll == collection then
     cleanup()
   end
   one_point_two()
+  -- / GRID pattern restore
+
   for i = 1,3 do
-    local dirname = _path.data .. "cheat_codes/arc-patterns/collection-"..params:get("collection").."/encoder-"..i..".data"
-    if os.rename(dirname, dirname) ~= nil then
-      load_arc_pattern(i)
-    end
+    load_arc_pattern(i)
   end
-  -- for i = 1,3 do
-  --   local dirname = _path.data .. "cheat_codes/arc-patterns/collection-"..params:get("collection").."/encoder-"..i..".data"
-  --   if os.rename(dirname, dirname) ~= nil then
-  --     load_arc_pattern(i)
-  --   end
-  -- end
+
   for i = 1,3 do
-    local dirname = _path.data .. "cheat_codes/midi-patterns/collection-"..params:get("collection").."/"..i..".data"
+    local dirname = _path.data .. "cheat_codes2/collection-"..selected_coll.."/patterns/midi"..i..".data"
     if os.rename(dirname, dirname) ~= nil then
       load_midi_pattern(i)
     end
   end
-  del.loadstate(selected_coll)
+
+
   grid_dirty = true
+
 end
+
+-- function testsavestate()
+--   local file = io.open(_path.data .. "cheat_codes2/collections"..tonumber(string.format("%.0f",params:get("collection")))..".data", "w+")
+--   io.output(file)
+--   io.write("PERMANENCE".."\n")
+--   for i = 1,3 do
+--     for k = 1,16 do 
+--       io.write(bank[i].id .. "\n")
+--       io.write(selected[i].x .. "\n")
+--       io.write(selected[i].y .. "\n")
+--       io.write(bank[i][k].clip .. "\n")
+--       io.write(bank[i][k].mode .. "\n")
+--       io.write(bank[i][k].start_point .. "\n")
+--       io.write(bank[i][k].end_point .. "\n")
+--       io.write(bank[i][k].rate .. "\n")
+--       io.write(tostring(bank[i][k].pause) .. "\n")
+--       io.write(tostring(bank[i][k].play_mode) .. "\n")
+--       io.write(bank[i][k].level .. "\n")
+--       io.write(tostring(bank[i][k].loop) .. "\n")
+--       io.write(tostring(bank[i][k].fifth) .. "\n")
+--       io.write(bank[i][k].pan .. "\n")
+--       io.write(bank[i][k].fc .. "\n")
+--       io.write(bank[i][k].q .. "\n")
+--       io.write(bank[i][k].lp .. "\n")
+--       io.write(bank[i][k].hp .. "\n")
+--       io.write(bank[i][k].bp .. "\n")
+--       io.write(bank[i][k].fd .. "\n")
+--       io.write(bank[i][k].br .. "\n")
+--       io.write(bank[i][k].filter_type .. "\n")
+--       io.write(arc_control[i] .. "\n")
+--       io.write(arc_param[i] .. "\n")
+--     end
+--     io.write(params:get("rate slew time ".. i) .. "\n")
+--     io.write(tostring(params:get("clip "..i.." sample") .. "\n"))
+--     local sides = {"delay L: ", "delay R: "}
+--     for k = 1,2 do
+--       io.write(params:get(sides[k].."div/mult") .. "\n")
+--       io.write(params:get(sides[k].."global level") .. "\n")
+--       io.write(params:get(sides[k].."feedback") .. "\n")
+--       io.write(params:get(sides[k].."(a) send") .. "\n")
+--       io.write(params:get(sides[k].."(b) send") .. "\n")
+--       io.write(params:get(sides[k].."(c) send") .. "\n")
+--       io.write(params:get(sides[k].."filter cut") .. "\n")
+--       io.write(params:get(sides[k].."filter q") .. "\n")
+--       io.write(params:get(sides[k].."filter lp") .. "\n")
+--       io.write(params:get(sides[k].."filter hp") .. "\n")
+--       io.write(params:get(sides[k].."filter bp") .. "\n")
+--       io.write(params:get(sides[k].."filter dry") .. "\n")
+--     end
+--   end
+--   io.write(params:get("offset").."\n")
+--     -- v1.1 items
+--   io.write("v1.1".."\n")
+--   for i = 1,3 do
+--     for k = 1,16 do
+--       io.write(tostring(bank[i][k].enveloped) .. "\n")
+--       io.write(bank[i][k].envelope_time .. "\n")
+--     end
+--   end
+--   io.write(params:get("zilchmo_patterning") .. "\n")
+--   io.write(params:get("rec_loop") .. "\n")
+--   io.write(params:get("live_rec_feedback") .. "\n")
+--   io.write(params:get("quantize_pads") .. "\n")
+--   io.write(params:get("quantize_pats") .. "\n")
+--   io.write(params:get("quant_div") .. "\n")
+--   io.write(params:get("quant_div_pats") .. "\n")
+--   io.write(params:get("bpm") .. "\n")
+--   io.write(rec.clip .. "\n")
+--   io.write(rec.start_point .. "\n")
+--   io.write(rec.end_point .. "\n")
+--   io.write("v1.1.1.1.1.1.1.1".."\n")
+--   for i = 1,3 do
+--     io.write(step_seq[i].active .. "\n")
+--     io.write(step_seq[i].meta_duration .. "\n")
+--     for k = 1,16 do
+--       io.write(step_seq[i][k].meta_meta_duration .. "\n")
+--       io.write(step_seq[i][k].assigned_to .. "\n")
+--       io.write(bank[i][k].tilt .. "\n")
+--       io.write(bank[i][k].tilt_ease_time .. "\n")
+--       io.write(bank[i][k].tilt_ease_type .. "\n")
+--     end
+--   end
+--   io.write("the last params".."\n")
+--   --io.write(params:get("clock_out") .. "\n")
+--   io.write("0".."\n")
+--   --io.write(params:get("crow_clock_out") .. "\n")
+--   io.write("0".."\n")
+--   --io.write(params:get("midi_device") .. "\n")
+--   io.write("0".."\n")
+--   io.write(params:get("loop_enc_resolution") .."\n")
+--   --io.write(params:get("clock") .. "\n")
+--   io.write("0".."\n")
+--   io.write(params:get("lock_pat") .. "\n")
+--   for i = 1,3 do
+--     io.write(bank[i].crow_execute .. "\n")
+--     io.write(bank[i].snap_to_bars .. "\n")
+--   end
+--   for i = 1,3 do
+--     for j = 1,16 do
+--       io.write(bank[i][j].offset .. "\n")
+--     end
+--   end
+--   io.write("crow execute count".."\n")
+--   for i = 1,3 do
+--     io.write(crow.count_execute[i] .. "\n")
+--   end
+--   io.write("step seq loop points".."\n")
+--   for i = 1,3 do
+--     io.write(step_seq[i].start_point .. "\n")
+--     io.write(step_seq[i].end_point .. "\n")
+--   end
+--   io.write("Live buffer max".."\n")
+--   io.write(params:get"live_buff_rate" .. "\n")
+--   io.write("loop Pattern per step".."\n")
+--   for i = 1,3 do
+--     for k = 1,16 do
+--       io.write(step_seq[i][k].loop_pattern.."\n")
+--     end
+--   end
+--   io.write("collect live?".."\n")
+--   io.write(params:get("collect_live").."\n")
+--   if params:get("collect_live") == 2 then
+--     io.write("sample refs".."\n")
+--     for i = 1,3 do
+--       io.write("/home/we/dust/audio/cc_collection-samples/"..params:get("collection").."/".."cc_"..params:get("collection").."-"..i..".wav".."\n")
+--       collect_samples(i)
+--     end
+--   end
+--   io.write("last Pattern playmode".."\n")
+--   for i = 1,3 do
+--     io.write(grid_pat[i].playmode.."\n")
+--   end
+--   io.write("1.2.1: arc patterning".."\n")
+--   io.write(params:get("arc_patterning").."\n")
+--   io.write("1.2.2: crow_pad_execute".."\n")
+--   for i = 1,3 do
+--     for k = 1,16 do
+--       io.write(bank[i][k].crow_pad_execute.."\n")
+--     end
+--   end
+--   io.write("1.3: Pattern random pitch range".."\n")
+--   for i = 1,3 do
+--     io.write(grid_pat[i].random_pitch_range.."\n")
+--   end
+--   io.write("1.3.1".."\n")
+--   io.write("one_shot_clock_div: "..params:get("one_shot_clock_div").."\n")
+--   io.write("rec_loop_enc_resolution: "..params:get("rec_loop_enc_resolution").."\n")
+--   io.write("more 1.3.1".."\n")
+--   io.write("random_rec_clock_prob: "..params:get("random_rec_clock_prob").."\n")
+
+--   io.write("cc2.0".."\n")
+
+--   io.close(file)
+--   if selected_coll ~= params:get("collection") then
+--     meta_copy_coll(selected_coll,params:get("collection"))
+--   end
+--   meta_shadow(params:get("collection"))
+--   --maybe not this? want to clean up
+--   selected_coll = params:get("collection")
+--   for i = 1,3 do
+--     if arc_pat[i][1].count > 0 then
+--       save_arc_pattern(i)
+--     end
+--     save_midi_pattern(i)
+--   end
+--   for i = 1,2 do
+--     del.savestate(i,selected_coll)
+--   end
+--   rnd.savestate()
+--   arps.savestate()
+--   rytm.savestate()
+-- end
+
+-- function testloadstate()
+--   selected_coll = params:get("collection")
+--   local file = io.open(_path.data .. "cheat_codes2/collections"..selected_coll..".data", "r")
+--   if file then
+--     io.input(file)
+--     pre_cc2_sample = { false, false, false }
+--     restored_clip_file = {"","",""}
+--     if io.read() == "PERMANENCE" then
+--       for i = 1,3 do
+--         for k = 1,16 do
+--           bank[i].id = tonumber(io.read())
+--           selected[i].x = tonumber(io.read())
+--           selected[i].y = tonumber(io.read())
+--           bank[i][k].clip = tonumber(io.read())
+--           bank[i][k].mode = tonumber(io.read())
+--           bank[i][k].start_point = tonumber(io.read())
+--           bank[i][k].end_point = tonumber(io.read())
+--           bank[i][k].rate = tonumber(io.read())
+--           local pause_to_boolean = io.read()
+--           if pause_to_boolean == "true" then
+--             bank[i][k].pause = true
+--           else
+--             bank[i][k].pause = false
+--           end
+--           bank[i][k].play_mode = io.read()
+--           bank[i][k].level = tonumber(io.read())
+--           local loop_to_boolean = io.read()
+--           if loop_to_boolean == "true" then
+--             bank[i][k].loop = true
+--           else
+--             bank[i][k].loop = false
+--           end
+--           local fifth_to_boolean = io.read()
+--           if fifth_to_boolean == "true" then
+--             bank[i][k].fifth = true
+--           else
+--             bank[i][k].fifth = false
+--           end
+--           bank[i][k].pan = tonumber(io.read())
+--           bank[i][k].fc = tonumber(io.read())
+--           bank[i][k].q = tonumber(io.read())
+--           bank[i][k].lp = tonumber(io.read())
+--           bank[i][k].hp = tonumber(io.read())
+--           bank[i][k].bp = tonumber(io.read())
+--           bank[i][k].fd = tonumber(io.read())
+--           bank[i][k].br = tonumber(io.read())
+--           tonumber(io.read())
+--           bank[i][k].filter_type = 4
+--           arc_control[i] = tonumber(io.read())
+--           arc_param[i] = tonumber(io.read())
+--         end
+--       params:set("rate slew time ".. i,tonumber(io.read()))
+--       local string_to_sample = io.read()
+--       restored_clip_file[i] = string_to_sample
+--       -- params:set("clip "..i.." sample", string_to_sample)
+--       local sides = {"delay L: ", "delay R: "}
+--       for k = 1,2 do
+--         params:set(sides[k].."div/mult",tonumber(io.read()))
+--         params:set(sides[k].."global level",tonumber(io.read()))
+--         params:set(sides[k].."feedback",tonumber(io.read()))
+--         params:set(sides[k].."(a) send",tonumber(io.read()))
+--         params:set(sides[k].."(b) send",tonumber(io.read()))
+--         params:set(sides[k].."(c) send",tonumber(io.read()))
+--         params:set(sides[k].."filter cut",tonumber(io.read()))
+--         params:set(sides[k].."filter q",tonumber(io.read()))
+--         params:set(sides[k].."filter lp",tonumber(io.read()))
+--         params:set(sides[k].."filter hp",tonumber(io.read()))
+--         params:set(sides[k].."filter bp",tonumber(io.read()))
+--         params:set(sides[k].."filter dry",tonumber(io.read()))
+--       end
+--     end
+--     params:set("offset",tonumber(io.read()))
+--     else
+--       print("invalid data file")
+--     end
+--     if io.read() == "v1.1" then
+--       for i = 1,3 do
+--         for k = 1,16 do
+--           local enveloped_to_boolean = io.read()
+--           if enveloped_to_boolean == "true" then
+--             bank[i][k].enveloped = true
+--           else
+--             bank[i][k].enveloped = false
+--           end
+--           bank[i][k].envelope_time = tonumber(io.read())
+--         end
+--       end
+--       params:set("zilchmo_patterning",tonumber(io.read()))
+--       params:set("rec_loop",tonumber(io.read()))
+--       params:set("live_rec_feedback",tonumber(io.read()))
+--       tonumber(io.read()) -- kill off quantize_pads
+--       params:set("quantize_pads",1)
+--       tonumber(io.read()) -- kill off quantize_pats
+--       params:set("quantize_pats",1)
+--       tonumber(io.read()) -- kill off quant_div
+--       params:set("quant_div",4)
+--       params:set("quant_div_pats",tonumber(io.read()))
+--       local bpm_to_clock = tonumber(io.read())
+--       params:set("bpm",bpm_to_clock)
+--       params:set("clock_tempo",bpm_to_clock)
+--       rec.clip = tonumber(io.read())
+--       rec.start_point = tonumber(io.read())
+--       rec.end_point = tonumber(io.read())
+--       softcut.loop_start(1,rec.start_point)
+--       softcut.loop_end(1,rec.end_point-0.01)
+--       softcut.position(1,rec.start_point)
+--     end
+--     if io.read() == "v1.1.1.1.1.1.1.1" then
+--       for i = 1,3 do
+--         step_seq[i].active = tonumber(io.read())
+--         step_seq[i].meta_duration = tonumber(io.read())
+--         for k = 1,16 do
+--           step_seq[i][k].meta_meta_duration = tonumber(io.read())
+--           step_seq[i][k].assigned_to = tonumber(io.read())
+--           bank[i][k].tilt = tonumber(io.read())
+--           bank[i][k].tilt_ease_time = tonumber(io.read())
+--           bank[i][k].tilt_ease_type = tonumber(io.read())
+--         end
+--       end
+--     end
+--     if io.read() == "the last params" then
+--       --params:set("clock_out",tonumber(io.read()))
+--       local disregard = tonumber(io.read())
+--       --params:set("crow_clock_out",tonumber(io.read()))
+--       local disregard = tonumber(io.read())
+--       --params:set("midi_device",tonumber(io.read()))
+--       local disregard = tonumber(io.read())
+--       params:set("loop_enc_resolution",tonumber(io.read()))
+--       --params:set("clock",tonumber(io.read()))
+--       local disregard_the_clock_source = tonumber(io.read())
+--       local disregard = tonumber(io.read())
+--       params:set("lock_pat",1)
+--       for i = 1,3 do
+--         bank[i].crow_execute = tonumber(io.read())
+--         bank[i].snap_to_bars = tonumber(io.read())
+--       end
+--       for i = 1,3 do
+--         for j = 1,16 do
+--           bank[i][j].offset = tonumber(io.read())
+--         end
+--       end
+--     end
+--     if io.read() == "crow execute count" then
+--       for i = 1,3 do
+--         crow.count_execute[i] = tonumber(io.read())
+--       end
+--     end
+--     if io.read() == "step seq loop points" then
+--       for i = 1,3 do
+--         step_seq[i].start_point = tonumber(io.read())
+--         step_seq[i].current_step = step_seq[i].start_point
+--         step_seq[i].end_point = tonumber(io.read())
+--       end
+--     end
+--     if io.read() == "Live buffer max" then
+--       params:set("live_buff_rate",tonumber(io.read()))
+--     end
+--     if io.read() == "loop Pattern per step" then
+--       for i = 1,3 do
+--         for k = 1,16 do
+--           step_seq[i][k].loop_pattern = tonumber(io.read())
+--         end
+--       end
+--     end
+--     if io.read() == "collect live?" then
+--       local restore_live = tonumber(io.read())
+--       params:set("collect_live",restore_live)
+--       if restore_live == 2 then
+--         if io.read() == "sample refs" then
+--           for i = 1,3 do
+--             local string_to_sample = io.read()
+--             reload_collected_samples(string_to_sample,i)
+--           end
+--         end
+--       end
+--     end
+--     if io.read() == "last Pattern playmode" then
+--       for i = 1,3 do
+--         local pm = tonumber(io.read())
+--         if pm == 3 or pm == 4 then
+--           grid_pat[i].playmode = 2
+--           params:set("pattern_"..i.."_quantization",2)
+--         else
+--           grid_pat[i].playmode = 1
+--         end
+--       end
+--     end
+--     if io.read() == "1.2.1: arc patterning" then
+--       params:set("arc_patterning", tonumber(io.read()))
+--     end
+--     if io.read() == "1.2.2: crow_pad_execute" then
+--       for i = 1,3 do
+--         for k = 1,16 do
+--           bank[i][k].crow_pad_execute = tonumber(io.read())
+--         end
+--       end
+--     end
+--     if io.read() == "1.3: Pattern random pitch range" then
+--       for i  = 1,3 do
+--         grid_pat[i].random_pitch_range = tonumber(io.read())
+--       end
+--     end
+--     if io.read() == "1.3.1" then
+--       params:set("one_shot_clock_div", tonumber(string.match(io.read(), ': (.*)')))
+--       params:set("rec_loop_enc_resolution", tonumber(string.match(io.read(), ': (.*)')))
+--     end
+--     if io.read() == "more 1.3.1" then
+--       params:set("random_rec_clock_prob", tonumber(string.match(io.read(), ': (.*)')))
+--     end
+--     if io.read() == "cc2.0" then
+--       for i = 1,3 do
+--         pre_cc2_sample[i] = true -- WHY
+--         params:set("clip "..i.." sample", restored_clip_file[i])
+--       end
+--     else
+--       for i = 1,3 do
+--         pre_cc2_sample[i] = true
+--         params:set("clip "..i.." sample", restored_clip_file[i])
+--       end
+--     end
+      
+--     io.close(file)
+
+--     rnd.loadstate()
+--     arps.loadstate()
+--     rytm.loadstate()
+
+--     for i = 1,3 do
+--       if bank[i][bank[i].id].loop == true then
+--         cheat(i,bank[i].id)
+--       else
+--         softcut.loop(i+1, 0)
+--         softcut.position(i+1,bank[i][bank[i].id].start_point)
+--       end
+--     end
+--   end
+--   already_saved()
+
+--   --- unpack quantized table here?
+
+--   for i = 1,3 do
+--     if step_seq[i].active == 1 and step_seq[i][step_seq[i].current_step].assigned_to ~= 0 then
+--       test_load(step_seq[i][step_seq[i].current_step].assigned_to+((i-1)*8),i)
+--     end
+--   end
+--   --maybe?
+--   if selected_coll ~= params:get("collection") then
+--     print("not selected coll!")
+--     meta_shadow(selected_coll)
+--   elseif selected_coll == params:get("collection") then
+--     cleanup()
+--   end
+--   one_point_two()
+--   for i = 1,3 do
+--     local dirname = _path.data .. "cheat_codes2/arc-patterns/collection-"..params:get("collection").."/encoder-"..i..".data"
+--     if os.rename(dirname, dirname) ~= nil then
+--       load_arc_pattern(i)
+--     end
+--   end
+--   -- for i = 1,3 do
+--   --   local dirname = _path.data .. "cheat_codes2/arc-patterns/collection-"..params:get("collection").."/encoder-"..i..".data"
+--   --   if os.rename(dirname, dirname) ~= nil then
+--   --     load_arc_pattern(i)
+--   --   end
+--   -- end
+--   for i = 1,3 do
+--     local dirname = _path.data .. "cheat_codes2/midi-patterns/collection-"..params:get("collection").."/"..i..".data"
+--     if os.rename(dirname, dirname) ~= nil then
+--       load_midi_pattern(i)
+--     end
+--   end
+--   del.loadstate(selected_coll)
+--   grid_dirty = true
+-- end
 
 function test_save(i)
   pattern_saver[i].active = true
@@ -4366,7 +4440,18 @@ function test_load(slot,destination)
 end
 
 function save_pattern(source,slot,style)
-  local file = io.open(_path.data .. "cheat_codes/pattern"..selected_coll.."_"..slot..".data", "w+")
+
+  local dirname = _path.data.."cheat_codes2/collection-"..selected_coll.."/"
+  if os.rename(dirname, dirname) == nil then
+    os.execute("mkdir " .. dirname)
+  end
+  local dirname = _path.data.."cheat_codes2/collection-"..selected_coll.."/patterns/"
+  if os.rename(dirname, dirname) == nil then
+    os.execute("mkdir " .. dirname)
+  end
+
+  local file = io.open(_path.data .. "cheat_codes2/collection-"..selected_coll.."/patterns/"..slot..".data", "w+")
+  -- local file = io.open(_path.data .. "cheat_codes2/pattern"..selected_coll.."_"..slot..".data", "w+")
   io.output(file)
   if style == "pattern" then
     io.write("stored pad pattern: collection "..selected_coll.." + slot "..slot.."\n")
@@ -4454,7 +4539,7 @@ function save_pattern(source,slot,style)
     --/GIRAFFE
     print("saved pattern "..source.." to slot "..slot)
   elseif style == "arp" then
-    tab.save(arp[source],_path.data .. "cheat_codes/pattern"..selected_coll.."_"..slot..".data")
+    tab.save(arp[source],_path.data .. "cheat_codes2/collection-"..selected_coll.."/patterns/"..slot..".data")
     print("saved arp "..source.." to slot "..slot)
   end
 end
@@ -4462,21 +4547,20 @@ end
 function already_saved()
   for i = 1,24 do
     local line_count = 0
-    local file = io.open(_path.data .. "cheat_codes/pattern"..selected_coll.."_"..i..".data", "r")
+    local file = io.open(_path.data .. "cheat_codes2/collection-"..selected_coll.."/patterns/"..i..".data", "r")
     if file then
       io.input(file)
-      for lines in io.lines(_path.data .. "cheat_codes/pattern"..selected_coll.."_"..i..".data") do
+      for lines in io.lines(_path.data .. "cheat_codes2/collection-"..selected_coll.."/patterns/"..i..".data") do
         line_count = line_count + 1
       end
       if line_count > 0 then
-      -- if io.read() == "stored pad pattern: collection "..selected_coll.." + slot "..i then
         local current = math.floor((i-1)/8)+1
         pattern_saver[current].saved[i-(8*(current-1))] = 1
       else
         local current = math.floor((i-1)/8)+1
         pattern_saver[current].saved[i-(8*(current-1))] = 0
         -- print("killing yr file4387")
-        os.remove(_path.data .. "cheat_codes/pattern" ..selected_coll.."_"..i..".data")
+        os.remove(_path.data .. "cheat_codes2/collection-"..selected_coll.."/patterns/"..i..".data")
       end
       io.close(file)
     else
@@ -4488,32 +4572,13 @@ end
 
 function one_point_two()
   for i = 1,24 do
-    local file = io.open(_path.data .. "cheat_codes/pattern"..selected_coll.."_"..i..".data", "r")
-    -- print(file)
+    local file = io.open(_path.data .. "cheat_codes2/collection-"..selected_coll.."/patterns/"..i..".data", "r")
     if file then
       io.input(file)
       local current = math.floor((i-1)/8)+1
       load_pattern(i,current)
       io.close(file)
     end
-
-
-
-    --   io.input(file)
-    --   if io.read() == "stored pad pattern: collection "..selected_coll.." + slot "..i then
-    --     local current = math.floor((i-1)/8)+1
-    --             ---
-    --     --create pre-1.2 external files
-    --     local ext_file = io.open(_path.data .. "cheat_codes/external-timing/pattern"..selected_coll.."_"..i.."_external-timing.data", "r")
-    --     if ext_file then
-    --       io.close(ext_file)
-    --     else
-    --       load_pattern(i,current)
-    --     end
-    --   else
-    --   end
-    --   io.close(file)
-    -- end
   end
   for i = 1,3 do
     grid_pat[i]:rec_stop()
@@ -4526,53 +4591,36 @@ end
 
 function clear_zero()
   for i = 1,24 do
-    local file = io.open(_path.data .. "cheat_codes/pattern0_"..i..".data", "r")
+    local file = io.open(_path.data .. "cheat_codes2/collection-0/patterns/"..i..".data", "r")
     if file then
       io.input(file)
       local line_count = 0
-      for lines in io.lines(_path.data .. "cheat_codes/pattern0_"..i..".data") do
+      for lines in io.lines(_path.data .. "cheat_codes2/collection-0/patterns/"..i..".data") do
         line_count = line_count + 1
       end
       if line_count > 0 then
-      -- if io.read() == "stored pad pattern: collection 0 + slot "..i then
-        os.remove(_path.data .. "cheat_codes/pattern0_"..i..".data")
+        os.remove(_path.data .. "cheat_codes2/collection-0/patterns/"..i..".data")
         print("cleared default pattern")
       end
       io.close(file)
     end
   end
-  -- for i = 1,24 do
-  --   local external_timing_file = io.open(_path.data .. "cheat_codes/external-timing/pattern0_"..i.."_external-timing.data", "r")
-  --   if external_timing_file then
-  --     io.input(external_timing_file)
-  --     if io.read() == "external clock timing for stored pad pattern: collection 0 + slot "..i then
-  --       os.remove(_path.data .. "cheat_codes/external-timing/pattern0_"..i.."_external-timing.data")
-  --       print("cleared default external timing")
-  --     end
-  --     io.close(external_timing_file)
-  --   end
-  -- end
 end
 
 function delete_pattern(slot)
-  local file = io.open(_path.data .. "cheat_codes/pattern"..selected_coll.."_"..slot..".data", "w+")
+  local file = io.open(_path.data .. "cheat_codes2/collection-"..selected_coll.."/patterns/"..slot..".data", "w+")
   io.output(file)
   io.write()
   io.close(file)
   print("deleted pattern from slot "..slot)
-  -- local external_timing_file = io.open(_path.data .. "cheat_codes/external-timing/pattern"..selected_coll.."_"..slot.."_external-timing.data", "w+")
-  -- io.output(external_timing_file)
-  -- io.write()
-  -- io.close(external_timing_file)
-  -- print("deleted external timing from slot "..slot)
 end
 
 function copy_pattern_across_coll(read_coll,write_coll,slot)
-  local infile = io.open(_path.data .. "cheat_codes/pattern"..read_coll.."_"..slot..".data", "r")
-  local outfile = io.open(_path.data .. "cheat_codes/pattern"..write_coll.."_"..slot..".data", "w+")
+  print("4610: "..read_coll,write_coll,slot)
+  local infile = io.open(_path.data .. "cheat_codes2/collection-"..read_coll.."/patterns/"..slot..".data", "r")
+  local outfile = io.open(_path.data .. "cheat_codes2/collection-"..write_coll.."/patterns/"..slot..".data", "w+")
   io.output(outfile)
   for line in infile:lines() do
-    -- io.write(line.."\n")
     if line == "stored pad pattern: collection "..read_coll.." + slot "..slot then
       io.write("stored pad pattern: collection "..write_coll.." + slot "..slot.."\n")
     else
@@ -4581,27 +4629,12 @@ function copy_pattern_across_coll(read_coll,write_coll,slot)
   end
   io.close(infile)
   io.close(outfile)
-
-  --/externalshadow
-  -- local external_timing_infile = io.open(_path.data .. "cheat_codes/external-timing/pattern"..read_coll.."_"..slot.."_external-timing.data", "r")
-  -- local external_timing_outfile = io.open(_path.data .. "cheat_codes/external-timing/pattern"..write_coll.."_"..slot.."_external-timing.data", "w+")
-  -- io.output(external_timing_outfile)
-  -- for line in external_timing_infile:lines() do
-  --   if line == "external clock timing for stored pad pattern: collection "..read_coll.." + slot "..slot then
-  --     io.write("external clock timing for stored pad pattern: collection "..write_coll.." + slot "..slot.."\n")
-  --   else
-  --     io.write(line.."\n")
-  --   end
-  -- end
-  -- io.close(external_timing_infile)
-  -- io.close(external_timing_outfile)
-  --externalshadow/
   
 end
 
 function shadow_pattern(read_coll,write_coll,slot)
-  local infile = io.open(_path.data .. "cheat_codes/pattern"..read_coll.."_"..slot..".data", "r")
-  local outfile = io.open(_path.data .. "cheat_codes/shadow-pattern"..write_coll.."_"..slot..".data", "w+")
+  local infile = io.open(_path.data .. "cheat_codes2/collection-"..read_coll.."/patterns/"..slot..".data", "r")
+  local outfile = io.open(_path.data .. "cheat_codes2/collection-"..write_coll.."/patterns/shadow-pattern_"..slot..".data", "w+")
   io.output(outfile)
   for line in infile:lines() do
     -- io.write(line.."\n")
@@ -4613,22 +4646,6 @@ function shadow_pattern(read_coll,write_coll,slot)
   end
   io.close(infile)
   io.close(outfile)
-  
-  --/externalshadow
-  -- local external_timing_infile = io.open(_path.data .. "cheat_codes/external-timing/pattern"..read_coll.."_"..slot.."_external-timing.data", "r")
-  -- local external_timing_outfile = io.open(_path.data .. "cheat_codes/external-timing/shadow-pattern"..write_coll.."_"..slot.."_external-timing.data", "w+")
-  -- io.output(external_timing_outfile)
-  -- for line in external_timing_infile:lines() do
-  --   if line == "external clock timing for stored pad pattern: collection "..read_coll.." + slot "..slot then
-  --     io.write("external clock timing for stored pad pattern: collection "..write_coll.." + slot "..slot.."\n")
-  --   else
-  --     io.write(line.."\n")
-  --   end
-  -- end
-  -- io.close(external_timing_infile)
-  -- io.close(external_timing_outfile)
-  --externalshadow/
-
 end
 
 function meta_shadow(coll)
@@ -4637,22 +4654,12 @@ function meta_shadow(coll)
       if pattern_saver[i].saved[j] == 1 then
         shadow_pattern(coll,coll,j+(8*(i-1)))
       elseif pattern_saver[i].saved[j] == 0 then
-        local file = io.open(_path.data .. "cheat_codes/shadow-pattern"..coll.."_"..j+(8*(i-1))..".data", "w+")
-        -- need an already saved shadow thing here to clear out
+        local file = io.open(_path.data .. "cheat_codes2/collection-"..coll.."/patterns/shadow-pattern_"..j+(8*(i-1))..".data", "w+")
         if file then
           io.output(file)
           io.write()
           io.close(file)
         end
-        
-        --/externalshadow
-        -- local external_timing_file = io.open(_path.data .. "cheat_codes/external-timing/shadow-pattern"..coll.."_"..j+(8*(i-1)).."_external-timing.data", "w+")
-        -- if external_timing_file then
-        --   io.output(external_timing_file)
-        --   io.write()
-        --   io.close(external_timing_file)
-        -- end
-        --externalshadow/
       end
     end
   end
@@ -4660,21 +4667,20 @@ end
 
 function clear_empty_shadows(coll)
   for i = 1,24 do
-    local file = io.open(_path.data .. "cheat_codes/shadow-pattern"..coll.."_"..i..".data", "r")
+    local file = io.open(_path.data .. "cheat_codes2/collection-"..coll.."/patterns/shadow-pattern_"..i..".data", "r")
     if file then
       io.input(file)
       local line_count = 0
-      for lines in io.lines(_path.data .. "cheat_codes/shadow-pattern"..coll.."_"..i..".data") do
+      for lines in io.lines(_path.data .. "cheat_codes2/collection-"..coll.."/patterns/shadow-pattern_"..i..".data") do
         line_count = line_count + 1
       end
-      -- if io.read() == "stored pad pattern: collection "..coll.." + slot "..i then
       if line_count > 0 then
         local current = math.floor((i-1)/8)+1
         pattern_saver[current].saved[i-(8*(current-1))] = 1
       else
         local current = math.floor((i-1)/8)+1
         pattern_saver[current].saved[i-(8*(current-1))] = 0
-        os.remove(_path.data .. "cheat_codes/shadow-pattern" ..coll.."_"..i..".data")
+        os.remove(_path.data .. "cheat_codes2/collection-"..coll.."/patterns/shadow-pattern_"..i..".data")
       end
       io.close(file)
     else
@@ -4682,34 +4688,14 @@ function clear_empty_shadows(coll)
       pattern_saver[current].saved[i-(8*(current-1))] = 0
     end
   end
-  
-  --/externalshadow
-  -- for i = 1,24 do
-  --   local file = io.open(_path.data .. "cheat_codes/external-timing/shadow-pattern"..coll.."_"..i.."_external-timing.data", "r")
-  --   if file then
-  --     io.input(file)
-  --     if io.read() == "external clock timing for stored pad pattern: collection "..coll.." + slot "..i then
-  --       local current = math.floor((i-1)/8)+1
-  --       pattern_saver[current].saved[i-(8*(current-1))] = 1
-  --     else
-  --       local current = math.floor((i-1)/8)+1
-  --       pattern_saver[current].saved[i-(8*(current-1))] = 0
-  --       os.remove(_path.data .. "cheat_codes/external-timing/shadow-pattern" ..coll.."_"..i.."_external-timing.data")
-  --     end
-  --     io.close(file)
-  --   end
-  -- end
-  --externalshadow/
-  
 end
 
 function shadow_to_play(coll,slot)
-  local infile = io.open(_path.data .. "cheat_codes/shadow-pattern"..coll.."_"..slot..".data", "r")
-  local outfile = io.open(_path.data .. "cheat_codes/pattern"..coll.."_"..slot..".data", "w+")
+  local infile = io.open(_path.data .. "cheat_codes2/collection-"..coll.."/patterns/shadow-pattern_"..slot..".data", "r")
+  local outfile = io.open(_path.data .. "cheat_codes2/collection-"..coll.."/patterns/"..slot..".data", "w+")
   io.output(outfile)
   if infile then
     for line in infile:lines() do
-      -- io.write(line.."\n")
       if line == "stored pad pattern: collection "..coll.." + slot "..slot then
         io.write("stored pad pattern: collection "..coll.." + slot "..slot.."\n")
       else
@@ -4719,24 +4705,6 @@ function shadow_to_play(coll,slot)
     io.close(infile)
     io.close(outfile)
   end
-  
-  --/externalshadow
-  -- local external_timing_infile = io.open(_path.data .. "cheat_codes/external-timing/shadow-pattern"..coll.."_"..slot.."_external-timing.data", "r")
-  -- local external_timing_outfile = io.open(_path.data .. "cheat_codes/external-timing/pattern"..coll.."_"..slot.."_external-timing.data", "w+")
-  -- io.output(external_timing_outfile)
-  -- if external_timing_infile then
-  --   for line in external_timing_infile:lines() do
-  --     if line == "external clock timing for stored pad pattern: collection "..coll.." + slot "..slot then
-  --       io.write("external clock timing for stored pad pattern: collection "..coll.." + slot "..slot.."\n")
-  --     else
-  --       io.write(line.."\n")
-  --     end
-  --   end
-  --   io.close(external_timing_infile)
-  --   io.close(external_timing_outfile)
-  -- end
-  --externalshadow/
-  
 end
 
 function meta_copy_coll(read_coll,write_coll)
@@ -4745,22 +4713,12 @@ function meta_copy_coll(read_coll,write_coll)
       if pattern_saver[i].saved[j] == 1 then
         copy_pattern_across_coll(read_coll,write_coll,j+(8*(i-1)))
       elseif pattern_saver[i].saved[j] == 0 then
-        local file = io.open(_path.data .. "cheat_codes/pattern"..write_coll.."_"..j+(8*(i-1))..".data", "w+")
+        local file = io.open(_path.data .. "cheat_codes2/collection-"..write_coll.."/patterns/"..j+(8*(i-1))..".data", "w+")
         if file then
           io.output(file)
           io.write()
           io.close(file)
-        end
-        
-        --/externalshadow
-        -- local external_timing_file = io.open(_path.data .. "cheat_codes/external-timing/pattern"..write_coll.."_"..j+(8*(i-1)).."_external-timing.data", "w+")
-        -- if external_timing_file then
-        --   io.output(external_timing_file)
-        --   io.write()
-        --   io.close(external_timing_file)
-        -- end
-        --externalshadow/
-        
+        end        
       end
     end
   end
@@ -4768,7 +4726,7 @@ end
 
 function load_pattern(slot,destination)
   local ignore_external_timing = false
-  local file = io.open(_path.data .. "cheat_codes/pattern"..selected_coll.."_"..slot..".data", "r")
+  local file = io.open(_path.data .. "cheat_codes2/collection-"..selected_coll.."/patterns/"..slot..".data", "r")
   if file then
     io.input(file)
     if io.read() == "stored pad pattern: collection "..selected_coll.." + slot "..slot then
@@ -4892,7 +4850,8 @@ function load_pattern(slot,destination)
       --/new stuff, quantum and time_beats!
     else
       -- print("it's an arp!")
-      arp[destination] = tab.load(_path.data .. "cheat_codes/pattern"..selected_coll.."_"..slot..".data")
+      arp[destination] = tab.load(_path.data .. "cheat_codes2/collection-"..selected_coll.."/patterns/"..slot..".data")
+      -- arp[destination] = tab.load(_path.data .. "cheat_codes2/pattern"..selected_coll.."_"..slot..".data")
       ignore_external_timing = true
     end
 
@@ -4915,24 +4874,20 @@ function cleanup()
   
   --need all this to just happen at cleanup after save
   for i = 1,24 do
-    local file = io.open(_path.data .. "cheat_codes/pattern"..selected_coll.."_"..i..".data", "r")
+    local file = io.open(_path.data .. "cheat_codes2/collection-"..selected_coll.."/patterns/"..i..".data", "r")
     if file then
       io.input(file)
       local line_count = 0
-      for lines in io.lines(_path.data .. "cheat_codes/pattern"..selected_coll.."_"..i..".data") do
+      for lines in io.lines(_path.data .. "cheat_codes2/collection-"..selected_coll.."/patterns/"..i..".data") do
         line_count = line_count + 1
       end
-      -- print(line_count, _path.data .. "cheat_codes/pattern" ..selected_coll.."_"..i..".data")
       if line_count > 0 then
-        -- if io.read() == "stored pad pattern: collection "..selected_coll.." + slot "..i then
           local current = math.floor((i-1)/8)+1
           pattern_saver[current].saved[i-(8*(current-1))] = 1
-        -- end
       else
         local current = math.floor((i-1)/8)+1
         pattern_saver[current].saved[i-(8*(current-1))] = 0
-        -- print("killing uyr file 4831", _path.data .. "cheat_codes/pattern" ..selected_coll.."_"..i..".data")
-        os.remove(_path.data .. "cheat_codes/pattern" ..selected_coll.."_"..i..".data")
+        os.remove(_path.data .. "cheat_codes2/collection-"..selected_coll.."/patterns/"..i..".data")
       end
       io.close(file)
     else
@@ -4940,124 +4895,87 @@ function cleanup()
       pattern_saver[current].saved[i-(8*(current-1))] = 0
     end
   end
-  
-  --/externalshadow
-  -- for i = 1,24 do
-  --   local file = io.open(_path.data .. "cheat_codes/external-timing/pattern"..selected_coll.."_"..i.."_external-timing.data", "r")
-  --   if file then
-  --     io.input(file)
-  --     if io.read() == "external clock timing for stored pad pattern: collection "..selected_coll.." + slot "..i then
-  --       local current = math.floor((i-1)/8)+1
-  --       pattern_saver[current].saved[i-(8*(current-1))] = 1
-  --     else
-  --       local current = math.floor((i-1)/8)+1
-  --       pattern_saver[current].saved[i-(8*(current-1))] = 0
-  --       os.remove(_path.data .. "cheat_codes/external-timing/pattern" ..selected_coll.."_"..i.."_external-timing.data")
-  --     end
-  --     io.close(file)
-  --   else
-  --     --print("can't clean these external files?")
-  --   end
-  -- end
-  --externalshadow/
-  
   clear_empty_shadows(selected_coll)
 end
 
 -- arc pattern stuff!
 
 function save_arc_pattern(which)
-  local dirname = _path.data.."cheat_codes/arc-patterns/"
-  if os.rename(dirname, dirname) == nil then
-    os.execute("mkdir " .. dirname)
-  end
-  
-  local dirname = _path.data.."cheat_codes/arc-patterns/collection-"..selected_coll.."/"
-  if os.rename(dirname, dirname) == nil then
-    os.execute("mkdir " .. dirname)
-  end
-  
-  local file = io.open(_path.data .. "cheat_codes/arc-patterns/collection-"..selected_coll.."/encoder-"..which..".data", "w+")
+  local file = io.open(_path.data .. "cheat_codes2/collection-"..selected_coll.."/arc-rec/encoder-"..which..".data", "w+")
   io.output(file)
   io.write("stored arc pattern: collection "..selected_coll.." + encoder "..which.."\n")
-  io.write(arc_pat[which].count .. "\n")
-  for i = 1,arc_pat[which].count do
-    io.write(arc_pat[which].time[i] .. "\n")
-    io.write(arc_pat[which].event[i].i .. "\n")
-    io.write(arc_pat[which].event[i].param .. "\n")
-    io.write(arc_pat[which].event[i].pad .. "\n")
-    io.write(arc_pat[which].event[i].start_point .. "\n")
-    io.write(arc_pat[which].event[i].end_point .. "\n")
-    io.write(arc_pat[which].event[i].prev_tilt .. "\n")
-    io.write(arc_pat[which].event[i].tilt .. "\n")
+  for j = 1,4 do
+    io.write("total events in recording "..j..": "..arc_pat[which][j].count .. "\n")
+    for i = 1,arc_pat[which][j].count do
+      io.write("event "..i.." time: "..arc_pat[which][j].time[i] .. "\n")
+      io.write("event "..i.." i1: "..arc_pat[which][j].event[i].i1 .. "\n")
+      io.write("event "..i.." i2: "..arc_pat[which][j].event[i].i2 .. "\n")
+      io.write("event "..i.." param: "..arc_pat[which][j].event[i].param .. "\n")
+      io.write("event "..i.." pad: "..arc_pat[which][j].event[i].pad .. "\n")
+      io.write("event "..i.." start point: "..arc_pat[which][j].event[i].start_point .. "\n")
+      io.write("event "..i.." end point: "..arc_pat[which][j].event[i].end_point .. "\n")
+      io.write("event "..i.." prev tilt: "..arc_pat[which][j].event[i].prev_tilt .. "\n")
+      io.write("event "..i.." tilt: "..arc_pat[which][j].event[i].tilt .. "\n")
+      io.write("event "..i.." pan: "..arc_pat[which][j].event[i].pan .. "\n")
+      io.write("event "..i.." level: "..arc_pat[which][j].event[i].level .. "\n")
+    end
+    io.write("recording "..j.." props time: "..arc_pat[which][j].metro.props.time .. "\n")
+    io.write("recording "..j.." prev time: "..arc_pat[which][j].prev_time .. "\n")
+    io.write("recording "..j.." start point: " .. arc_pat[which][j].start_point .. "\n")
+    io.write("recording "..j.." end point: " .. arc_pat[which][j].end_point .. "\n")
   end
-  io.write(arc_pat[which].metro.props.time .. "\n")
-  io.write(arc_pat[which].prev_time .. "\n")
-  io.write("start point: " .. arc_pat[which].start_point .. "\n")
-  io.write("end point: " .. arc_pat[which].end_point .. "\n")
   io.close(file)
   print("saved arc pattern for encoder "..which)
 end
 
 function load_arc_pattern(which)
-  local file = io.open(_path.data .. "cheat_codes/arc-patterns/collection-"..selected_coll.."/encoder-"..which..".data", "r")
+  local file = io.open(_path.data .. "cheat_codes2/collection-"..selected_coll.."/arc-rec/encoder-"..which..".data", "r")
   if file then
     io.input(file)
     if io.read() == "stored arc pattern: collection "..selected_coll.." + encoder "..which then
-      arc_pat[which].event = {}
-      arc_pat[which].count = tonumber(io.read())
-      for i = 1,arc_pat[which].count do
-        arc_pat[which].time[i] = tonumber(io.read())
-        arc_pat[which].event[i] = {}
-        arc_pat[which].event[i].i = {}
-        arc_pat[which].event[i].param = {}
-        arc_pat[which].event[i].pad = {}
-        arc_pat[which].event[i].start_point = {}
-        arc_pat[which].event[i].end_point = {}
-        arc_pat[which].event[i].prev_tilt = {}
-        arc_pat[which].event[i].tilt = {}
-        --
-        arc_pat[which].event[i].i = tonumber(io.read())
-        arc_pat[which].event[i].param = tonumber(io.read())
-        arc_pat[which].event[i].pad = tonumber(io.read())
-        arc_pat[which].event[i].start_point = tonumber(io.read())
-        arc_pat[which].event[i].end_point = tonumber(io.read())
-        arc_pat[which].event[i].prev_tilt = tonumber(io.read())
-        arc_pat[which].event[i].tilt = tonumber(io.read())
-      end
-      arc_pat[which].metro.props.time = tonumber(io.read())
-      arc_pat[which].prev_time = tonumber(io.read())
-      local new_arc_array = io.read()
-      if new_arc_array ~= nil then
-        arc_pat[which].start_point = tonumber(string.match(new_arc_array, ': (.*)'))
-      else
-        arc_pat[which].start_point = 1
-      end
-      local new_arc_array = io.read()
-      if new_arc_array ~= nil then
-        arc_pat[which].end_point = tonumber(string.match(new_arc_array, ': (.*)'))
-      else
-        arc_pat[which].end_point = arc_pat[which].count
+      for j = 1,4 do
+        arc_pat[which][j].event = {}
+        arc_pat[which][j].count = tonumber(string.match(io.read(), ': (.*)'))
+        for i = 1,arc_pat[which][j].count do
+          arc_pat[which][j].time[i] = tonumber(string.match(io.read(), ': (.*)'))
+          arc_pat[which][j].event[i] = {}
+          arc_pat[which][j].event[i].i1 = {}
+          arc_pat[which][j].event[i].i2 = {}
+          arc_pat[which][j].event[i].param = {}
+          arc_pat[which][j].event[i].pad = {}
+          arc_pat[which][j].event[i].start_point = {}
+          arc_pat[which][j].event[i].end_point = {}
+          arc_pat[which][j].event[i].prev_tilt = {}
+          arc_pat[which][j].event[i].tilt = {}
+          arc_pat[which][j].event[i].pan = {}
+          arc_pat[which][j].event[i].level = {}
+          --
+          arc_pat[which][j].event[i].i1 = tonumber(string.match(io.read(), ': (.*)'))
+          arc_pat[which][j].event[i].i2 = tonumber(string.match(io.read(), ': (.*)'))
+          arc_pat[which][j].event[i].param = tonumber(string.match(io.read(), ': (.*)'))
+          arc_pat[which][j].event[i].pad =tonumber(string.match(io.read(), ': (.*)'))
+          arc_pat[which][j].event[i].start_point = tonumber(string.match(io.read(), ': (.*)'))
+          arc_pat[which][j].event[i].end_point = tonumber(string.match(io.read(), ': (.*)'))
+          arc_pat[which][j].event[i].prev_tilt = tonumber(string.match(io.read(), ': (.*)'))
+          arc_pat[which][j].event[i].tilt = tonumber(string.match(io.read(), ': (.*)'))
+          arc_pat[which][j].event[i].pan = tonumber(string.match(io.read(), ': (.*)'))
+          arc_pat[which][j].event[i].level = tonumber(string.match(io.read(), ': (.*)'))
+        end
+        arc_pat[which][j].metro.props.time = tonumber(string.match(io.read(), ': (.*)'))
+        arc_pat[which][j].prev_time = tonumber(string.match(io.read(), ': (.*)'))
+        arc_pat[which][j].start_point = tonumber(string.match(io.read(), ': (.*)'))
+        arc_pat[which][j].end_point = tonumber(string.match(io.read(), ': (.*)'))
       end
     end
     io.close(file)
+    grid_dirty = true
   else
     print("nofile")
   end
 end
 
 function save_midi_pattern(which)
-  local dirname = _path.data.."cheat_codes/midi-patterns/"
-  if os.rename(dirname, dirname) == nil then
-    os.execute("mkdir " .. dirname)
-  end
-  
-  local dirname = _path.data.."cheat_codes/midi-patterns/collection-"..selected_coll.."/"
-  if os.rename(dirname, dirname) == nil then
-    os.execute("mkdir " .. dirname)
-  end
-  
-  local file = io.open(_path.data .. "cheat_codes/midi-patterns/collection-"..selected_coll.."/"..which..".data", "w+")
+  local file = io.open(_path.data .. "cheat_codes2/collection-"..selected_coll.."/patterns/midi"..which..".data", "w+")
   io.output(file)
   if midi_pat[which].count > 0 then
     io.write("stored midi pattern: collection "..selected_coll..", pattern "..which.."\n")
@@ -5081,7 +4999,7 @@ function save_midi_pattern(which)
 end
 
 function load_midi_pattern(which)
-  local file = io.open(_path.data .. "cheat_codes/midi-patterns/collection-"..selected_coll.."/"..which..".data", "r")
+  local file = io.open(_path.data .. "cheat_codes2/collection-"..selected_coll.."/patterns/midi"..which..".data", "r")
   if file then
     io.input(file)
     if io.read() == "stored midi pattern: collection "..selected_coll..", pattern "..which then

--- a/cheat_codes.lua
+++ b/cheat_codes.lua
@@ -3713,10 +3713,15 @@ arc_redraw = function()
       end
     end
     if arc_param[i] == 5 then
-      local level_to_led = bank[i][bank[i].id].level
-        for j = 1,17 do
-          a:led(i,(math.floor(util.linlin(0,2,5,70,(level_to_led)-(1/8*j))))+16,15)
-        end
+      local level_to_led;
+      if not key1_hold and not bank[i].alt_lock and grid.alt == 0 then
+        level_to_led = bank[i][bank[i].id].level
+      else
+        level_to_led = bank[i].global_level
+      end
+      for j = 1,17 do
+        a:led(i,(math.floor(util.linlin(0,2,5,70,(level_to_led)-(1/8*j))))+16,15)
+      end
     end
     if arc_param[i] == 6 then
       local pan_to_led = bank[i][bank[i].id].pan

--- a/lib/arc_actions.lua
+++ b/lib/arc_actions.lua
@@ -17,13 +17,13 @@ function aa.init(n,d)
     local this_pad = this_bank[which_pad]
     local p_action = aa.actions[arc_param[n]][1]
     local sc_action = aa.actions[arc_param[n]][2]
-    if grid.alt == 0 then
+    if not this_bank.alt_lock and grid.alt == 0 then
       if arc_param[n] ~= 4 then
         p_action(this_pad,d)
       else
         aa.map(p_action, this_bank, d/1000, n)
       end
-    else
+    elseif this_bank.alt_lock or grid.alt == 1 then
       if arc_param[n] ~= 4 then
         aa.map(p_action,this_bank,d)
       else
@@ -161,7 +161,13 @@ function aa.change_pan(target, delta)
 end
 
 function aa.change_level(target, delta)
-  target.level = util.clamp(target.level + delta/1000,0,2)
+  if not bank[target.bank_id].alt_lock and grid.alt == 0 then
+    target.level = util.clamp(target.level + delta/1000,0,2)
+  else
+    if target.pad_id == 1 then
+      bank[target.bank_id].global_level = util.clamp(bank[target.bank_id].global_level + delta/1000,0,2)
+    end
+  end
 end
 
 function aa.sc.move_window(enc, target)

--- a/lib/arc_actions.lua
+++ b/lib/arc_actions.lua
@@ -18,16 +18,20 @@ function aa.init(n,d)
     local p_action = aa.actions[arc_param[n]][1]
     local sc_action = aa.actions[arc_param[n]][2]
     if not this_bank.alt_lock and grid.alt == 0 then
-      if arc_param[n] ~= 4 then
+      -- if arc_param[n] ~= 4 then
+      -- if arc_param[n] < 4 then
+      if arc_param[n] ~= 4 and arc_param[n] ~= 5 then
         p_action(this_pad,d)
       else
-        aa.map(p_action, this_bank, d/1000, n)
+        aa.map(p_action, this_bank, arc_param[n] == 4 and d/1000 or d, n)
       end
     elseif this_bank.alt_lock or grid.alt == 1 then
-      if arc_param[n] ~= 4 then
+      -- if arc_param[n] ~= 4 then
+      -- if arc_param[n] < 4 then
+      if arc_param[n] ~= 4 and arc_param[n] ~= 5 then
         aa.map(p_action,this_bank,d)
       else
-        p_action(this_pad,d/1000, n)
+        p_action(this_pad, arc_param[n] == 4 and d/1000 or d, n)
       end
     end
     if this_bank.focus_hold == false or this_bank.focus_pad == this_bank.id then
@@ -163,11 +167,11 @@ end
 
 function aa.change_level(target, delta)
   if not bank[target.bank_id].alt_lock and grid.alt == 0 then
-    target.level = util.clamp(target.level + delta/1000,0,2)
-  else
     if target.pad_id == 1 then
       bank[target.bank_id].global_level = util.clamp(bank[target.bank_id].global_level + delta/1000,0,2)
     end
+  else
+    target.level = util.clamp(target.level + delta/1000,0,2)
   end
 end
 

--- a/lib/arc_actions.lua
+++ b/lib/arc_actions.lua
@@ -37,9 +37,10 @@ function aa.init(n,d)
       aa.record(n)
     end
   else
-    local side = (arc.alt == nil or arc.alt == 0) and "L" or "R"
-    aa.delay_rate(d,side)
-    aa.record_delay(side)
+    -- local side = (arc.alt == nil or arc.alt == 0) and "L" or "R"
+    -- aa.delay_rate(d,side)
+    -- aa.record_delay(side)
+    aa.change_param_focus(d)
   end
   redraw()
 end
@@ -79,28 +80,39 @@ function aa.map(fn, bank, delta, enc)
   end
 end
 
-function aa.delay_rate(d,side)
-  local chan = side == "L" and 1 or 2
-  delay[chan].arc_rate_tracker = util.clamp(delay[chan].arc_rate_tracker + d/10,1,13)
-  delay[chan].arc_rate = math.floor(delay[chan].arc_rate_tracker)
-  params:set("delay "..side..": rate",math.floor(delay[chan].arc_rate_tracker))
+function aa.change_param_focus(d)
+  local start = util.round(arc_meta_focus)
+  arc_meta_focus = util.clamp(arc_meta_focus+d/33,1,6)
+  if start ~= util.round(arc_meta_focus) then
+    for i = 1,3 do
+      arc_param[i] = util.round(arc_meta_focus)
+    end
+    grid_dirty = true
+  end
 end
+
+-- function aa.delay_rate(d,side)
+--   local chan = side == "L" and 1 or 2
+--   delay[chan].arc_rate_tracker = util.clamp(delay[chan].arc_rate_tracker + d/10,1,13)
+--   delay[chan].arc_rate = math.floor(delay[chan].arc_rate_tracker)
+--   params:set("delay "..side..": rate",math.floor(delay[chan].arc_rate_tracker))
+-- end
 
 function aa.record(enc)
   aa.new_pattern_watch(enc)
 end
 
-function aa.record_delay(side)
-  arc_p[side] = {}
-  arc_p[side].i = side
-  if grid.alt == 0 then
-    arc_p[side].delay_focus = "L"
-    arc_p[side].left_delay_value = params:get("delay L: rate")
-  else
-    arc_p[side].delay_focus = "R"
-    arc_p[side].right_delay_value = params:get("delay R: rate")
-  end
-end
+-- function aa.record_delay(side)
+--   arc_p[side] = {}
+--   arc_p[side].i = side
+--   if grid.alt == 0 then
+--     arc_p[side].delay_focus = "L"
+--     arc_p[side].left_delay_value = params:get("delay L: rate")
+--   else
+--     arc_p[side].delay_focus = "R"
+--     arc_p[side].right_delay_value = params:get("delay R: rate")
+--   end
+-- end
 
 function aa.move_window(target, delta)
   local duration = target.mode == 1 and 8 or clip[target.clip].sample_length

--- a/lib/arc_actions.lua
+++ b/lib/arc_actions.lua
@@ -174,7 +174,7 @@ function aa.sc.change_pan(enc, target)
 end
 
 function aa.sc.change_level(enc, target)
-  softcut.level(enc+1,target.level)
+  softcut.level(enc+1,target.level*bank[enc].global_level)
 end
 
 aa.actions =

--- a/lib/arc_actions.lua
+++ b/lib/arc_actions.lua
@@ -70,6 +70,7 @@ function aa.new_pattern_watch(enc)
   --new new!
   arc_p[enc][a_p].pan = bank[id][bank[id].id].pan
   arc_p[enc][a_p].level = bank[id][bank[id].id].level
+  arc_p[enc][a_p].global_level = bank[id].global_level
   --/new new!
   arc_pat[enc][a_p]:watch(arc_p[enc][a_p])
 end

--- a/lib/arc_actions.lua
+++ b/lib/arc_actions.lua
@@ -17,13 +17,13 @@ function aa.init(n,d)
     local this_pad = this_bank[which_pad]
     local p_action = aa.actions[arc_param[n]][1]
     local sc_action = aa.actions[arc_param[n]][2]
-    if not this_bank.alt_lock and grid.alt == 0 then
+    if not this_bank.alt_lock and not grid.alt then
       if arc_param[n] ~= 4 then
         p_action(this_pad,d)
       else
         aa.map(p_action, this_bank, arc_param[n] == 4 and d/1000 or d, n)
       end
-    elseif this_bank.alt_lock or grid.alt == 1 then
+    elseif this_bank.alt_lock or grid.alt then
       if arc_param[n] ~= 4 then
         aa.map(p_action,this_bank,d)
       else
@@ -99,7 +99,7 @@ function aa.move_window(target, delta)
   local current_difference = (target.end_point - target.start_point)
   local s_p = target.mode == 1 and live[target.clip].min or clip[target.clip].min
   local current_clip = duration*(target.clip-1)
-  local reasonable_max = target.mode == 1 and 9 or clip[target.clip].max+1
+  local reasonable_max = target.mode == 1 and 9 or clip[target.clip].max
   local adjusted_delta = force and (duration > 15 and (delta/25) or (delta/100)) or (delta/300)
   if target.start_point + current_difference <= reasonable_max then
     target.start_point = util.clamp(target.start_point + adjusted_delta, s_p, reasonable_max)
@@ -122,8 +122,9 @@ function aa.move_start(target, delta)
   local duration = target.mode == 1 and 8 or clip[target.clip].sample_length
   local s_p = target.mode == 1 and live[target.clip].min or clip[target.clip].min
   local adjusted_delta = force and (delta/100) or (delta/300)
-  if adjusted_delta >= 0 and target.start_point < (target.end_point - 0.05) then
+  if adjusted_delta >= 0 and target.start_point < (target.end_point - 0.055) then
     target.start_point = util.clamp(target.start_point+adjusted_delta,s_p,s_p+duration)
+    print(target.end_point)
   elseif adjusted_delta < 0 then
     target.start_point = util.clamp(target.start_point+adjusted_delta,s_p,s_p+duration)
   end
@@ -137,7 +138,7 @@ function aa.move_end(target, delta)
   local duration = target.mode == 1 and 8 or clip[target.clip].sample_length
   local s_p = target.mode == 1 and live[target.clip].min or clip[target.clip].min
   local adjusted_delta = force and (delta/100) or (delta/300)
-  if adjusted_delta <= 0 and target.start_point < (target.end_point - 0.05) then
+  if adjusted_delta <= 0 and target.start_point < (target.end_point - 0.055) then
     target.end_point = util.clamp(target.end_point+adjusted_delta,s_p,s_p+duration)
   elseif adjusted_delta > 0 then
     target.end_point = util.clamp(target.end_point+adjusted_delta,s_p,s_p+duration)
@@ -167,7 +168,7 @@ function aa.change_pan(target, delta)
 end
 
 function aa.change_level(target, delta)
-  if bank[target.bank_id].alt_lock or grid.alt == 1 then
+  if bank[target.bank_id].alt_lock or grid.alt then
     if target.pad_id == 1 then
       bank[target.bank_id].global_level = util.clamp(bank[target.bank_id].global_level + delta/1000,0,2)
     end

--- a/lib/arp_actions.lua
+++ b/lib/arp_actions.lua
@@ -147,26 +147,26 @@ end
 
 function arp_actions.savestate()
   local collection = params:get("collection")
-  local dirname = _path.data.."cheat_codes/arp/"
+  local dirname = _path.data.."cheat_codes2/arp/"
   if os.rename(dirname, dirname) == nil then
     os.execute("mkdir " .. dirname)
   end
   
-  local dirname = _path.data.."cheat_codes/arp/collection-"..collection.."/"
+  local dirname = _path.data.."cheat_codes2/arp/collection-"..collection.."/"
   if os.rename(dirname, dirname) == nil then
     os.execute("mkdir " .. dirname)
   end
 
   for i = 1,3 do
-    tab.save(arp[i],_path.data .. "cheat_codes/arp/collection-"..collection.."/"..i..".data")
+    tab.save(arp[i],_path.data .. "cheat_codes2/arp/collection-"..collection.."/"..i..".data")
   end
 end
 
 function arp_actions.loadstate()
   local collection = params:get("collection")
   for i = 1,3 do
-    if tab.load(_path.data .. "cheat_codes/arp/collection-"..collection.."/"..i..".data") ~= nil then
-      arp[i] = tab.load(_path.data .. "cheat_codes/arp/collection-"..collection.."/"..i..".data")
+    if tab.load(_path.data .. "cheat_codes2/arp/collection-"..collection.."/"..i..".data") ~= nil then
+      arp[i] = tab.load(_path.data .. "cheat_codes2/arp/collection-"..collection.."/"..i..".data")
       -- arp[i].clock = nil
       -- arp[i].pause = true
       -- arp[i].playing = false

--- a/lib/delay.lua
+++ b/lib/delay.lua
@@ -205,7 +205,9 @@ function delays.set_value(target,index,param)
           bank[delay_grid.bank][i].left_delay_level = send_levels[index]
         end
       end
-      softcut.level_cut_cut(delay_grid.bank+1,5,util.linlin(-1,1,0,1,b.pan)*(b.left_delay_level*b.level))
+      softcut.level_slew_time(5,0.25)
+      -- softcut.level_cut_cut(delay_grid.bank+1,5,util.linlin(-1,1,0,1,b.pan)*(b.left_delay_level*b.level))
+      softcut.level_cut_cut(delay_grid.bank+1,5,(b.left_delay_level*b.level)*bank[delay_grid.bank].global_level)
     else
       if param == "send" then
         b.right_delay_level = send_levels[index]
@@ -214,7 +216,9 @@ function delays.set_value(target,index,param)
           bank[delay_grid.bank][i].right_delay_level = send_levels[index]
         end
       end
-      softcut.level_cut_cut(delay_grid.bank+1,6,util.linlin(-1,1,1,0,b.pan)*(b.right_delay_level*b.level))
+      softcut.level_slew_time(6,0.25)
+      -- softcut.level_cut_cut(delay_grid.bank+1,6,util.linlin(-1,1,1,0,b.pan)*(b.right_delay_level*b.level))
+      softcut.level_cut_cut(delay_grid.bank+1,6,(b.right_delay_level*b.level)*bank[delay_grid.bank].global_level)
     end
   end
 end

--- a/lib/delay.lua
+++ b/lib/delay.lua
@@ -120,24 +120,24 @@ end
 
 function delays.savestate(source,collection)
   local del_name = source == 1 and "L" or "R"
-  local dirname = _path.data.."cheat_codes/delays/"
+  local dirname = _path.data.."cheat_codes2/delays/"
   if os.rename(dirname, dirname) == nil then
     os.execute("mkdir " .. dirname)
   end
   
-  local dirname = _path.data.."cheat_codes/delays/collection-"..collection.."/"
+  local dirname = _path.data.."cheat_codes2/delays/collection-"..collection.."/"
   if os.rename(dirname, dirname) == nil then
     os.execute("mkdir " .. dirname)
   end
 
-  tab.save(delay_bundle[source],_path.data .. "cheat_codes/delays/collection-"..collection.."/"..del_name..".data")
+  tab.save(delay_bundle[source],_path.data .. "cheat_codes2/delays/collection-"..collection.."/"..del_name..".data")
 end
 
 function delays.loadstate(collection)
   local del_name = {"L","R"}
   for i = 1,2 do
-    if tab.load(_path.data .. "cheat_codes/delays/collection-"..collection.."/"..del_name[i]..".data") ~= nil then
-      delay_bundle[i] = tab.load(_path.data .. "cheat_codes/delays/collection-"..collection.."/"..del_name[i]..".data")
+    if tab.load(_path.data .. "cheat_codes2/delays/collection-"..collection.."/"..del_name[i]..".data") ~= nil then
+      delay_bundle[i] = tab.load(_path.data .. "cheat_codes2/delays/collection-"..collection.."/"..del_name[i]..".data")
     end
   end
 end
@@ -297,12 +297,12 @@ end
 
 
 function delays.save_delay(source)
-  local dirname = _path.dust.."audio/cc_saved_delays/"
+  local dirname = _path.dust.."audio/cc2_saved-delays/"
   if os.rename(dirname, dirname) == nil then
     os.execute("mkdir " .. dirname)
   end
 
-  local dirname = _path.dust.."audio/cc_saved_delays/"..os.date("%y%m%d").."/"
+  local dirname = _path.dust.."audio/cc2_saved-delays/"..os.date("%y%m%d").."/"
   if os.rename(dirname, dirname) == nil then
     os.execute("mkdir " .. dirname)
   end
@@ -310,7 +310,7 @@ function delays.save_delay(source)
   local id = os.date("%X")
   local name = id.."-"..(source == 1 and "L-" or "R-")..params:get("bpm")..".wav"
   local duration = delay[source].mode == "clocked" and delay[source].end_point-delay[source].start_point or delay[source].free_end_point-delay[source].start_point
-  softcut.buffer_write_mono(_path.dust.."audio/cc_saved_delays/"..os.date("%y%m%d").."/"..name,delay[source].start_point,duration,1)
+  softcut.buffer_write_mono(_path.dust.."audio/cc2_saved-delays/"..os.date("%y%m%d").."/"..name,delay[source].start_point,duration,1)
 end
 
 function delays.load_delay(file,destination)

--- a/lib/delay.lua
+++ b/lib/delay.lua
@@ -83,6 +83,7 @@ function delays.build_bundle(target,slot)
     delay[target].selected_bundle = slot
   end
   delay[target].saver_active = false
+  grid_dirty = true
 end
 
 function delays.restore_bundle(target,slot)
@@ -182,8 +183,6 @@ function delays.quick_action(target,param)
       end
     else
       if not pad.enveloped then
-        print(pad.enveloped)
-        print("sending 185")
         softcut.level_cut_cut(delay_grid.bank+1,target+4,target == 1 and bank[delay_grid.bank][bank[delay_grid.bank].id].left_delay_level or bank[delay_grid.bank][bank[delay_grid.bank].id].right_delay_level)
       end
     end

--- a/lib/delay.lua
+++ b/lib/delay.lua
@@ -172,8 +172,7 @@ function delays.quick_action(target,param)
     delay[target].send_mute = not delay[target].send_mute
     if delay[target].send_mute then
       if (target == 1 and pad.left_delay_level or pad.right_delay_level) == 0 then
-        if pad.enveloped then
-        else
+        if not pad.enveloped then
           softcut.level_cut_cut(delay_grid.bank+1,target+4,1)
         end
       else
@@ -182,7 +181,9 @@ function delays.quick_action(target,param)
         end
       end
     else
-      if not pad.eveloped then
+      if not pad.enveloped then
+        print(pad.enveloped)
+        print("sending 185")
         softcut.level_cut_cut(delay_grid.bank+1,target+4,target == 1 and bank[delay_grid.bank][bank[delay_grid.bank].id].left_delay_level or bank[delay_grid.bank][bank[delay_grid.bank].id].right_delay_level)
       end
     end
@@ -214,9 +215,11 @@ function delays.set_value(target,index,param)
           bank[delay_grid.bank][i].left_delay_level = send_levels[index]
         end
       end
-      softcut.level_slew_time(5,0.25)
-      -- softcut.level_cut_cut(delay_grid.bank+1,5,util.linlin(-1,1,0,1,b.pan)*(b.left_delay_level*b.level))
-      softcut.level_cut_cut(delay_grid.bank+1,5,(b.left_delay_level*b.level)*bank[delay_grid.bank].global_level)
+      if not b.enveloped then
+        softcut.level_slew_time(5,0.25)
+        -- softcut.level_cut_cut(delay_grid.bank+1,5,util.linlin(-1,1,0,1,b.pan)*(b.left_delay_level*b.level))
+        softcut.level_cut_cut(delay_grid.bank+1,5,(b.left_delay_level*b.level)*bank[delay_grid.bank].global_level)
+      end
     else
       if param == "send" then
         b.right_delay_level = send_levels[index]
@@ -225,9 +228,11 @@ function delays.set_value(target,index,param)
           bank[delay_grid.bank][i].right_delay_level = send_levels[index]
         end
       end
-      softcut.level_slew_time(6,0.25)
-      -- softcut.level_cut_cut(delay_grid.bank+1,6,util.linlin(-1,1,1,0,b.pan)*(b.right_delay_level*b.level))
-      softcut.level_cut_cut(delay_grid.bank+1,6,(b.right_delay_level*b.level)*bank[delay_grid.bank].global_level)
+      if not b.enveloped then
+        softcut.level_slew_time(6,0.25)
+        -- softcut.level_cut_cut(delay_grid.bank+1,6,util.linlin(-1,1,1,0,b.pan)*(b.right_delay_level*b.level))
+        softcut.level_cut_cut(delay_grid.bank+1,6,(b.right_delay_level*b.level)*bank[delay_grid.bank].global_level)
+      end
     end
   end
 end
@@ -295,8 +300,8 @@ function delays.change_rate(target,param)
     end
   elseif param == "wobble" then
     local bump = {params:get("delay L: rate bump"), params:get("delay R: rate bump")}
-    local wobble = bump[target] == 1 and 0.5 or math.random(-75,75)/1000
-    softcut.rate(target+4,params:get(rate[target])+wobble)
+    local wobble = bump[target] == 1 and (params:get(rate[target]) * 1.5) or (params:get(rate[target])+math.random(-75,75)/1000)
+    softcut.rate(target+4,wobble)
     delay[target].wobble_hold = true
   elseif param == "restore" then
     softcut.rate(target+4,params:get(rate[target]))

--- a/lib/delay.lua
+++ b/lib/delay.lua
@@ -167,15 +167,24 @@ function delays.quick_action(target,param)
       softcut.pre_level(target+4,params:get(target == 1 and "delay L: feedback" or "delay R: feedback")/100)
     end
   elseif param == "send mute" then
+    -- softcut.level_slew_time(target+4,0.25)
+    local pad = bank[delay_grid.bank][bank[delay_grid.bank].id]
     delay[target].send_mute = not delay[target].send_mute
     if delay[target].send_mute then
-      if (target == 1 and bank[delay_grid.bank][bank[delay_grid.bank].id].left_delay_level or bank[delay_grid.bank][bank[delay_grid.bank].id].right_delay_level) == 0 then
-        softcut.level_cut_cut(delay_grid.bank+1,target+4,1)
+      if (target == 1 and pad.left_delay_level or pad.right_delay_level) == 0 then
+        if pad.enveloped then
+        else
+          softcut.level_cut_cut(delay_grid.bank+1,target+4,1)
+        end
       else
-        softcut.level_cut_cut(delay_grid.bank+1,target+4,0)
+        if not pad.enveloped then
+          softcut.level_cut_cut(delay_grid.bank+1,target+4,0)
+        end
       end
     else
-      softcut.level_cut_cut(delay_grid.bank+1,target+4,target == 1 and bank[delay_grid.bank][bank[delay_grid.bank].id].left_delay_level or bank[delay_grid.bank][bank[delay_grid.bank].id].right_delay_level)
+      if not pad.eveloped then
+        softcut.level_cut_cut(delay_grid.bank+1,target+4,target == 1 and bank[delay_grid.bank][bank[delay_grid.bank].id].left_delay_level or bank[delay_grid.bank][bank[delay_grid.bank].id].right_delay_level)
+      end
     end
   elseif param == "clear" then
     softcut.level(target+4,0)
@@ -271,7 +280,7 @@ function delays.sync_clock_to_length(source)
       derived_bpm = derived_bpm/2
       if derived_bpm <= 70 then break end
     end
-    params:set("bpm",derived_bpm)
+    params:set("clock_tempo",derived_bpm)
   end
 end
 

--- a/lib/encoder_actions.lua
+++ b/lib/encoder_actions.lua
@@ -6,7 +6,7 @@ ea.sc = {}
 function encoder_actions.init(n,d)
   if n == 1 then
     if menu == 1 then
-      page.main_sel = util.clamp(page.main_sel+d,1,10)
+      page.main_sel = util.clamp(page.main_sel+d,1,9)
     elseif menu == 2 then
       local id = page.loops_sel
       if not key1_hold then
@@ -63,7 +63,7 @@ function encoder_actions.init(n,d)
   end
   if n == 2 then
     if menu == 1 then
-      page.main_sel = util.clamp(page.main_sel+d,1,10)
+      page.main_sel = util.clamp(page.main_sel+d,1,9)
     elseif menu == 2 then
       local id = page.loops_sel
       if id ~=4 then
@@ -80,7 +80,7 @@ function encoder_actions.init(n,d)
               bank[id][i].rate = bank[id][16].rate
             end
           end
-          if grid.alt == 1 then
+          if grid.alt then
             for i = 1,16 do
               bank[id][i].rate = bank[id][focused_pad].rate
             end
@@ -272,7 +272,7 @@ function encoder_actions.init(n,d)
               bank[id][i].offset = bank[id][16].offset
             end
           end
-          if grid.alt == 1 then
+          if grid.alt then
             for i = 1,16 do
               bank[id][i].offset = bank[id][focused_pad].offset
             end
@@ -292,7 +292,7 @@ function encoder_actions.init(n,d)
               bank[id][i].rate_slew = bank[id][16].rate_slew
             end
           end
-          if grid.alt == 1 then
+          if grid.alt then
             for i = 1,16 do
               bank[id][i].rate_slew = bank[id][focused_pad].rate_slew
             end
@@ -615,7 +615,7 @@ function encoder_actions.init(n,d)
       focused_pad = bank[n].id
     end
     if page.levels_sel == 0 then
-      if key1_hold or grid.alt == 1 or bank[n].alt_lock then
+      if key1_hold or grid.alt or bank[n].alt_lock then
         -- for i = 1,16 do
         --   bank[n][i].level = util.clamp(bank[n][i].level+d/10,0,2)
         -- end
@@ -636,7 +636,7 @@ function encoder_actions.init(n,d)
       end
     elseif page.levels_sel == 1 then
 
-      if key1_hold or grid.alt == 1 or bank[n].alt_lock then
+      if key1_hold or grid.alt or bank[n].alt_lock then
         for j = 1,16 do
           local pre_enveloped = bank[n][j].enveloped
           local pre_mode = bank[n][j].envelope_mode
@@ -703,7 +703,7 @@ function encoder_actions.init(n,d)
       end
 
     elseif page.levels_sel == 2 then
-      if key1_hold or grid.alt == 1 or bank[n].alt_lock then
+      if key1_hold or grid.alt or bank[n].alt_lock then
         for j = 1,16 do
           if bank[n][j].enveloped then
             if d>0 then
@@ -730,7 +730,7 @@ function encoder_actions.init(n,d)
       end
 
     elseif page.levels_sel == 3 then
-      if key1_hold or grid.alt == 1 or bank[n].alt_lock then
+      if key1_hold or grid.alt or bank[n].alt_lock then
         for j = 1,16 do
           if bank[n][j].enveloped then
             bank[n][j].envelope_time = util.explin(0.1,60,0.1,60,bank[n][j].envelope_time)
@@ -750,7 +750,7 @@ function encoder_actions.init(n,d)
   end
   if menu == 4 then
     local focused_pad = nil
-    if key1_hold or grid.alt == 1 then
+    if key1_hold or grid.alt then
       for i = 1,16 do
         bank[n][i].pan = util.clamp(bank[n][i].pan+d/10,-1,1)
       end
@@ -767,7 +767,7 @@ function encoder_actions.init(n,d)
     local filt_page = page.filtering_sel + 1
     if filt_page == 1 then
       if bank[n][bank[n].id].filter_type == 4 then
-        if key1_hold or grid.alt == 1 then
+        if key1_hold or grid.alt then
           if slew_counter[n] ~= nil then
             slew_counter[n].prev_tilt = bank[n][bank[n].id].tilt
           end
@@ -802,7 +802,7 @@ function encoder_actions.init(n,d)
         end
       end
     elseif filt_page == 2 then
-      if key1_hold or grid.alt == 1 then
+      if key1_hold or grid.alt then
         bank[n][bank[n].id].tilt_ease_time = util.clamp(bank[n][bank[n].id].tilt_ease_time+(d/1), 5, 15000)
       else
         for j = 1,16 do
@@ -810,7 +810,7 @@ function encoder_actions.init(n,d)
         end
       end
     elseif filt_page == 3 then
-      if key1_hold or grid.alt == 1 then
+      if key1_hold or grid.alt then
         bank[n][bank[n].id].tilt_ease_type = util.clamp(bank[n][bank[n].id].tilt_ease_type+d, 1, 2)
       else
         for j = 1,16 do
@@ -933,7 +933,7 @@ end
 function ea.move_start(target,delta)
   local duration = target.mode == 1 and 8 or clip[target.clip].sample_length
   local s_p = target.mode == 1 and live[target.clip].min or clip[target.clip].min
-  if delta >= 0 and target.start_point < (target.end_point - delta) then
+  if delta >= 0 and target.start_point < (target.end_point - 0.05) then
     target.start_point = util.clamp(target.start_point+delta,s_p,s_p+duration)
   elseif delta < 0 then
     target.start_point = util.clamp(target.start_point+delta,s_p,s_p+duration)
@@ -943,7 +943,7 @@ end
 function ea.move_end(target,delta)
   local duration = target.mode == 1 and 8 or clip[target.clip].sample_length
   local s_p = target.mode == 1 and live[target.clip].min or clip[target.clip].min
-  if delta <= 0 and target.start_point < target.end_point + delta then
+  if delta <= 0 and target.start_point < (target.end_point - 0.05) then
     target.end_point = util.clamp(target.end_point+delta,s_p,s_p+duration)
   elseif delta > 0 then
     target.end_point = util.clamp(target.end_point+delta,s_p,s_p+duration)

--- a/lib/encoder_actions.lua
+++ b/lib/encoder_actions.lua
@@ -615,7 +615,7 @@ function encoder_actions.init(n,d)
       focused_pad = bank[n].id
     end
     if page.levels_sel == 0 then
-      if key1_hold or grid.alt == 1 then
+      if key1_hold or grid.alt == 1 or bank[n].alt_lock then
         -- for i = 1,16 do
         --   bank[n][i].level = util.clamp(bank[n][i].level+d/10,0,2)
         -- end
@@ -636,7 +636,7 @@ function encoder_actions.init(n,d)
       end
     elseif page.levels_sel == 1 then
 
-      if key1_hold or grid.alt == 1 then
+      if key1_hold or grid.alt == 1 or bank[n].alt_lock then
         for j = 1,16 do
           local pre_enveloped = bank[n][j].enveloped
           local pre_mode = bank[n][j].envelope_mode
@@ -703,7 +703,7 @@ function encoder_actions.init(n,d)
       end
 
     elseif page.levels_sel == 2 then
-      if key1_hold or grid.alt == 1 then
+      if key1_hold or grid.alt == 1 or bank[n].alt_lock then
         for j = 1,16 do
           if bank[n][j].enveloped then
             if d>0 then
@@ -730,7 +730,7 @@ function encoder_actions.init(n,d)
       end
 
     elseif page.levels_sel == 3 then
-      if key1_hold or grid.alt == 1 then
+      if key1_hold or grid.alt == 1 or bank[n].alt_lock then
         for j = 1,16 do
           if bank[n][j].enveloped then
             bank[n][j].envelope_time = util.explin(0.1,60,0.1,60,bank[n][j].envelope_time)
@@ -823,15 +823,32 @@ function encoder_actions.init(n,d)
 end
 
 function ea.move_play_window(target,delta)
+  -- local duration = target.mode == 1 and 8 or clip[target.clip].sample_length
+  -- local current_difference = (target.end_point - target.start_point)
+  -- local s_p = target.mode == 1 and live[target.clip].min or clip[target.clip].min
+  -- local current_clip = duration*(target.clip-1)
+  -- if target.start_point + current_difference <= s_p+duration then
+  --   target.start_point = util.clamp(target.start_point + delta, s_p, s_p+duration)
+  --   target.end_point = target.start_point + current_difference
+  -- else
+  --   target.end_point = s_p+duration
+  --   target.start_point = target.end_point - current_difference
+  -- end
+
   local duration = target.mode == 1 and 8 or clip[target.clip].sample_length
   local current_difference = (target.end_point - target.start_point)
   local s_p = target.mode == 1 and live[target.clip].min or clip[target.clip].min
   local current_clip = duration*(target.clip-1)
-  if target.start_point + current_difference <= s_p+duration then
-    target.start_point = util.clamp(target.start_point + delta, s_p, s_p+duration)
+  local reasonable_max = target.mode == 1 and 9 or clip[target.clip].max+1
+  if target.start_point + current_difference <= reasonable_max then
+    target.start_point = util.clamp(target.start_point + delta, s_p, reasonable_max)
     target.end_point = target.start_point + current_difference
   else
-    target.end_point = s_p+duration
+    target.end_point = reasonable_max
+    target.start_point = target.end_point - current_difference
+  end
+  if target.end_point > reasonable_max then
+    target.end_point = reasonable_max
     target.start_point = target.end_point - current_difference
   end
 end

--- a/lib/encoder_actions.lua
+++ b/lib/encoder_actions.lua
@@ -15,9 +15,9 @@ function encoder_actions.init(n,d)
       end
       if id ~= 4 then
         if key1_hold then
-          if page.loops_view[id] == 2 then
+          if page.loops_view[id] > 1 then
             ea.change_pad(id,d)
-          elseif page.loops_view[id] == 1 then
+          else
             local which_pad = nil
             if bank[id].focus_hold == false then
               which_pad = bank[id].id
@@ -56,13 +56,7 @@ function encoder_actions.init(n,d)
     elseif menu == 8 then
       rytm.track_edit = util.clamp(rytm.track_edit+d,1,3)
     elseif menu == 9 then
-      if key1_hold then
-        local working = arp[page.arp_page_sel].retrigger and 1 or 0
-        working = util.clamp(working+d,0,1)
-        arp[page.arp_page_sel].retrigger = (working == 1 and true or false)
-      else
-        page.arp_page_sel = util.clamp(page.arp_page_sel+d,1,3)
-      end
+      page.arp_page_sel = util.clamp(page.arp_page_sel+d,1,3)
     elseif menu == 10 then
       page.rnd_page = util.clamp(page.rnd_page+d,1,3)
     end
@@ -74,6 +68,24 @@ function encoder_actions.init(n,d)
       local id = page.loops_sel
       if id ~=4 then
         if page.loops_view[id] == 2 then
+          local focused_pad = nil
+          if grid_pat[id].play == 0 and grid_pat[id].tightened_start == 0 and not arp[id].playing and midi_pat[id].play == 0 then
+            focused_pad = bank[id].id
+          else
+            focused_pad = bank[id].focus_pad
+          end
+          params:delta("rate "..id,d)
+          if focused_pad == 16 then
+            for i = 1,15 do
+              bank[id][i].rate = bank[id][16].rate
+            end
+          end
+          if grid.alt == 1 then
+            for i = 1,16 do
+              bank[id][i].rate = bank[id][focused_pad].rate
+            end
+          end
+        elseif page.loops_view[id] == 3 then
           ea.change_pad_clip(id,d)
         elseif page.loops_view[id] == 1 then
           local which_pad = nil
@@ -220,112 +232,8 @@ function encoder_actions.init(n,d)
           rytm.track[rytm.track_edit].mode = "single"
         end
       end
-
-
-      --[==[
-      if page.track_page_section[page.track_page] == 1 then
-        --[[
-        page.track_page = util.clamp(page.track_page+d,1,4)
-        for i = 1,3 do
-          tracker[i].recording = false
-        end
-        --]]
-      elseif page.track_page_section[page.track_page] == 3 then
-        if page.track_page < 4 then
-          if tracker[page.track_page][page.track_sel[page.track_page]].pad == nil then
-            tracker[page.track_page][page.track_sel[page.track_page]].pad = 0
-            tracker[page.track_page][page.track_sel[page.track_page]].time = 3
-            if page.track_sel[page.track_page] > tracker[page.track_page].end_point then
-              tracker[page.track_page].end_point = page.track_sel[page.track_page]
-            end
-          end
-          tracker[page.track_page][page.track_sel[page.track_page]].pad = util.clamp(tracker[page.track_page][page.track_sel[page.track_page]].pad+d,1,16)
-          trackers.map_to(page.track_page,page.track_sel[page.track_page])
-        else
-          tracker[1].snake = util.clamp(tracker[1].snake+d,1,8)
-        end
-      elseif page.track_page_section[page.track_page] == 4 then
-        local id = page.track_page
-        local sel = page.track_param_sel[id]
-        local line = page.track_sel[id]
-        if sel == 1 then
-          if tracker[id][line].pad == nil then tracker[id][line].pad = 0 end
-          tracker[id][line].pad = util.clamp(tracker[id][line].pad+d,1,16)
-          trackers.map_to(id,line)
-        elseif sel == 2 then
-          local rate_to_int =
-          { [-4] = 1
-          , [-2] = 2
-          , [-1] = 3
-          , [-0.5] = 4
-          , [-0.25] = 5
-          , [-0.125] = 6
-          , [0.125] = 7
-          , [0.25] = 8
-          , [0.5] = 9
-          , [1] = 10
-          , [2] = 11
-          , [4] = 12
-          }
-          local tracker_rate = rate_to_int[tracker[id][line].rate]
-          local tracker_rate = util.clamp(tracker_rate+d,1,12)
-          local int_to_rate = {-4,-2,-1,-0.5,-0.25,-0.125,0.125,0.25,0.5,1,2,4}
-          tracker[id][line].rate = int_to_rate[tracker_rate]
-        elseif sel == 3 then
-          ea.move_start(tracker[id][line],d/loop_enc_resolution)
-        elseif sel == 4 then
-          ea.move_end(tracker[id][line],d/loop_enc_resolution)
-        elseif sel == 5 then
-          local bool_to_string = {["false"] = 1, ["true"] = 2}
-          local tracker_loop = bool_to_string[tostring(tracker[id][line].loop)]
-          tracker_loop = util.clamp(tracker_loop+d,1,2)
-          local int_to_bool = {false, true}
-          tracker[id][line].loop = int_to_bool[tracker_loop]
-        elseif sel == 6 then
-          local pre_adjust = tracker[id][line].clip
-          local current_difference = (tracker[id][line].end_point - tracker[id][line].start_point)
-          if tracker[id][line].mode == 1 and tracker[id][line].clip + d > 3 then
-            tracker[id][line].mode = 2
-            tracker[id][line].clip = 1
-          elseif tracker[id][line].mode == 2 and tracker[id][line].clip + d < 1 then
-            tracker[id][line].mode = 1
-            tracker[id][line].clip = 3
-          else
-            tracker[id][line].clip = util.clamp(tracker[id][line].clip+d,1,3)
-          end
-          tracker[id][line].start_point = tracker[id][line].start_point - ((pre_adjust - tracker[id][line].clip)*8)
-          tracker[id][line].end_point = tracker[id][line].start_point + current_difference
-        end
-        --trackers.map_similar(id,line)
-      end
-      --]==]
     elseif menu == 9 then
-      local focus_arp = arp[page.arp_page_sel]
-      if page.arp_param_group[page.arp_page_sel] == 2 then
-        focus_arp.start_point = util.clamp(focus_arp.start_point+d,1,focus_arp.end_point)
-      else
-        local deci_to_int =
-        { ["0.125"] = 1 --1/32
-        , ["0.1667"] = 2 --1/16T
-        , ["0.25"] = 3 -- 1/16
-        , ["0.3333"] = 4 -- 1/8T
-        , ["0.5"] = 5 -- 1/8
-        , ["0.6667"] = 6 -- 1/4T
-        , ["1.0"] = 7 -- 1/4
-        , ["1.3333"] = 8 -- 1/2T
-        , ["2.0"] = 9 -- 1/2
-        , ["2.6667"] = 10  -- 1T
-        , ["4.0"] = 11 -- 1
-        }
-        local rounded = util.round(focus_arp.time,0.0001)
-        local working = deci_to_int[tostring(rounded)]
-        working = util.clamp(working+d,1,11)
-        local int_to_deci = {0.125,1/6,0.25,1/3,0.5,2/3,1,4/3,2,8/3,4}
-        focus_arp.time = int_to_deci[working]
-        for i = 1,16 do
-          bank[page.arp_page_sel][i].arp_time = focus_arp.time
-        end
-      end
+      page.arp_param[page.arp_page_sel] = util.clamp(page.arp_param[page.arp_page_sel] + d,1,5)
     elseif menu == 10 then
       local selected_slot = page.rnd_page_sel[page.rnd_page]
       if page.rnd_page_section == 1 then
@@ -343,7 +251,7 @@ function encoder_actions.init(n,d)
     if menu == 2 then
       local id = page.loops_sel
       if id ~= 4 then
-        if page.loops_view[id] == 2 then
+        if page.loops_view[id] == 3 then
           local focused_pad = nil
           if grid_pat[id].play == 0 and grid_pat[id].tightened_start == 0 and not arp[id].playing and midi_pat[id].play == 0 then
             focused_pad = bank[id].id
@@ -369,6 +277,27 @@ function encoder_actions.init(n,d)
               bank[id][i].offset = bank[id][focused_pad].offset
             end
           end
+        
+        elseif page.loops_view[id] == 2 then
+          local focused_pad = nil
+          if grid_pat[id].play == 0 and grid_pat[id].tightened_start == 0 and not arp[id].playing and midi_pat[id].play == 0 then
+            focused_pad = bank[id].id
+          else
+            focused_pad = bank[id].focus_pad
+          end
+          bank[id][focused_pad].rate_slew = util.clamp(bank[id][focused_pad].rate_slew+d/10,0,4)
+          softcut.rate_slew_time(id+1,bank[id][focused_pad].rate_slew)
+          if focused_pad == 16 then
+            for i = 1,15 do
+              bank[id][i].rate_slew = bank[id][16].rate_slew
+            end
+          end
+          if grid.alt == 1 then
+            for i = 1,16 do
+              bank[id][i].rate_slew = bank[id][focused_pad].rate_slew
+            end
+          end
+          
         elseif page.loops_view[id] == 1 then
           local which_pad = nil
           if bank[id].focus_hold == false then
@@ -546,45 +475,59 @@ function encoder_actions.init(n,d)
         rytm.track[rytm.track_edit].clock_div = tonumber(deci[new_value])
       end
 
-      --[==[
-      if page.track_page_section[page.track_page] == 3 then
-        if tracker[page.track_page][page.track_sel[page.track_page]].pad ~= nil then
-        local numerator_to_sel =
-          { [2] = 1 --1/16T
-          , [3] = 2 -- 1/16
-          , [4] = 3 -- 1/8T
-          , [6] = 4 -- 1/8
-          , [8] = 5 -- 1/4T
-          , [12] = 6 -- 1/4
-          , [16] = 7 -- 1/2T
-          , [24] = 8 -- 1/2
-          , [32] = 9  -- 1T
-          , [48] = 10 -- 1
-          }
-          local working = numerator_to_sel[tracker[page.track_page][page.track_sel[page.track_page]].time]
-          working = util.clamp(working+d,1,10)
-          local int_to_numerator = {2,3,4,6,8,12,16,24,32,48}
-          tracker[page.track_page][page.track_sel[page.track_page]].time = int_to_numerator[working]
-        end
-      end
-      --]==]
     elseif menu == 9 then
-      if page.arp_param_group[page.arp_page_sel] == 2 then
-        if #arp[page.arp_page_sel].notes > 0 then
-          arp[page.arp_page_sel].end_point = util.clamp(arp[page.arp_page_sel].end_point+d,arp[page.arp_page_sel].start_point,#arp[page.arp_page_sel].notes)
+      local focus_arp = arp[page.arp_page_sel]
+      local id = page.arp_page_sel
+      if page.arp_param[id] == 1 then
+        local deci_to_int =
+        { ["0.125"] = 1 --1/32
+        , ["0.1667"] = 2 --1/16T
+        , ["0.25"] = 3 -- 1/16
+        , ["0.3333"] = 4 -- 1/8T
+        , ["0.5"] = 5 -- 1/8
+        , ["0.6667"] = 6 -- 1/4T
+        , ["1.0"] = 7 -- 1/4
+        , ["1.3333"] = 8 -- 1/2T
+        , ["2.0"] = 9 -- 1/2
+        , ["2.6667"] = 10  -- 1T
+        , ["4.0"] = 11 -- 1
+        }
+        local rounded = util.round(focus_arp.time,0.0001)
+        local working = deci_to_int[tostring(rounded)]
+        working = util.clamp(working+d,1,11)
+        local int_to_deci = {0.125,1/6,0.25,1/3,0.5,2/3,1,4/3,2,8/3,4}
+        if page.arp_alt[page.arp_page_sel] then
+          bank[page.arp_page_sel][bank[page.arp_page_sel].id].arp_time = int_to_deci[working]
+          focus_arp.time = bank[page.arp_page_sel][bank[page.arp_page_sel].id].arp_time
+        else
+          focus_arp.time = int_to_deci[working]
+          for i = 1,16 do
+            bank[page.arp_page_sel][i].arp_time = focus_arp.time
+          end
         end
-      else
+      elseif page.arp_param[id] == 2 then
         local dir_to_int =
         { ["fwd"] = 1
         , ["bkwd"] = 2
         , ["pend"] = 3
         , ["rnd"] = 4
         }
-        local dir = dir_to_int[arp[page.arp_page_sel].mode]
+        local dir = dir_to_int[focus_arp.mode]
         dir = util.clamp(dir+d,1,4)
         local int_to_dir = {"fwd","bkwd","pend","rnd"}
-        arp[page.arp_page_sel].mode = int_to_dir[dir]
+        focus_arp.mode = int_to_dir[dir]
+      elseif page.arp_param[id] == 3 then
+        focus_arp.start_point = util.clamp(focus_arp.start_point+d,1,focus_arp.end_point)
+      elseif page.arp_param[id] == 4 then
+        if #focus_arp.notes > 0 then
+          focus_arp.end_point = util.clamp(focus_arp.end_point+d,focus_arp.start_point,#focus_arp.notes)
+        end
+      elseif page.arp_param[id] == 5 then
+        local working = arp[page.arp_page_sel].retrigger and 0 or 1
+        working = util.clamp(working+d,0,1)
+        arp[page.arp_page_sel].retrigger = (working == 0 and true or false)
       end
+
     elseif menu == 10 then
       local current = rnd[page.rnd_page][page.rnd_page_sel[page.rnd_page]]
       if page.rnd_page_section == 2 then
@@ -673,63 +616,120 @@ function encoder_actions.init(n,d)
     end
     if page.levels_sel == 0 then
       if key1_hold or grid.alt == 1 then
-        for i = 1,16 do
-          bank[n][i].level = util.clamp(bank[n][i].level+d/10,0,2)
-        end
+        -- for i = 1,16 do
+        --   bank[n][i].level = util.clamp(bank[n][i].level+d/10,0,2)
+        -- end
+        bank[n].global_level = util.clamp(bank[n].global_level+d/10,0,2)
       else
         bank[n][focused_pad].level = util.clamp(bank[n][focused_pad].level+d/10,0,2)
       end
-      if bank[n][bank[n].id].enveloped == false then
+      -- TODO figure out of this is necessary:
+      -- it wouldn't let you adjust the volume on an enveloped
+      -- if bank[n][bank[n].id].enveloped == false then
+      if bank[n][bank[n].id].envelope_mode == 2 or bank[n][bank[n].id].enveloped == false then
         if bank[n].focus_hold == false then
           softcut.level_slew_time(n+1,1.0)
-          softcut.level(n+1,bank[n][bank[n].id].level)
-          softcut.level_cut_cut(n+1,5,util.linlin(-1,1,0,1,bank[n][bank[n].id].pan)*(bank[n][bank[n].id].left_delay_level*bank[n][bank[n].id].level))
-          softcut.level_cut_cut(n+1,6,util.linlin(-1,1,1,0,bank[n][bank[n].id].pan)*(bank[n][bank[n].id].right_delay_level*bank[n][bank[n].id].level))
+          softcut.level(n+1,bank[n][bank[n].id].level*bank[n].global_level)
+          softcut.level_cut_cut(n+1,5,(bank[n][bank[n].id].left_delay_level*bank[n][bank[n].id].level)*bank[n].global_level)
+          softcut.level_cut_cut(n+1,6,(bank[n][bank[n].id].right_delay_level*bank[n][bank[n].id].level)*bank[n].global_level)
         end
       end
     elseif page.levels_sel == 1 then
+
       if key1_hold or grid.alt == 1 then
         for j = 1,16 do
           local pre_enveloped = bank[n][j].enveloped
+          local pre_mode = bank[n][j].envelope_mode
+
+          bank[n][j].envelope_mode = util.clamp(bank[n][j].envelope_mode + d,0,3)
+
+          if bank[n][j].envelope_mode == 0 then
+            bank[n][j].enveloped = false
+            -- TODO: figure out if this is necessary
+            -- if pre_enveloped ~= bank[n][j].enveloped then
+            --   cheat(n, bank[n].id)
+            -- end
+          else
+            bank[n][j].enveloped = true
+            if pre_enveloped ~= bank[n][j].enveloped then
+              cheat(n, bank[n].id)
+            end
+          end
+
+          -- if bank[n][j].enveloped then
+          --   if d < 0 then
+          --     bank[n][j].enveloped = false
+          --     if pre_enveloped ~= bank[n][j].enveloped then
+          --       cheat(n, bank[n].id)
+          --     end
+          --   end
+          -- else
+          --   if d > 0 then
+          --     bank[n][j].enveloped = true
+          --     if pre_enveloped ~= bank[n][j].enveloped then
+          --       cheat(n, bank[n].id)
+          --     end
+          --   end
+          -- end
+          
+        end
+
+      else
+
+        local pre_enveloped = bank[n][focused_pad].enveloped
+        local pre_mode = bank[n][focused_pad].envelope_mode
+        bank[n][focused_pad].envelope_mode = util.clamp(bank[n][focused_pad].envelope_mode + d,0,3)
+        
+        if bank[n][focused_pad].envelope_mode == 0 then
+          bank[n][focused_pad].enveloped = false
+          -- if pre_enveloped ~= bank[n][bank[n].id].enveloped then
+          --   if bank[n].focus_hold == false then
+          --     cheat(n, bank[n].id)
+          --   end
+          -- end
+        else
+          bank[n][focused_pad].enveloped = true
+          if pre_enveloped ~= bank[n][focused_pad].enveloped then
+            if bank[n].focus_hold == false then
+              cheat(n, bank[n].id)
+            end
+          elseif pre_mode ~= bank[n][focused_pad].envelope_mode then
+            if bank[n].focus_hold == false then
+              cheat(n, bank[n].id)
+            end
+          end
+        end
+
+      end
+
+    elseif page.levels_sel == 2 then
+      if key1_hold or grid.alt == 1 then
+        for j = 1,16 do
           if bank[n][j].enveloped then
-            if d < 0 then
-              bank[n][j].enveloped = false
-              if pre_enveloped ~= bank[n][j].enveloped then
+            if d>0 then
+              bank[n][j].envelope_loop = true
+            else
+              bank[n][j].envelope_loop = false
+            end
+          end
+        end
+      else
+        if bank[n][focused_pad].enveloped then
+          local pre_loop = bank[n][focused_pad].envelope_loop
+          if d>0 then
+            bank[n][focused_pad].envelope_loop = true
+            if pre_loop ~= bank[n][focused_pad].envelope_loop then
+              if bank[n].focus_hold == false then
                 cheat(n, bank[n].id)
               end
             end
           else
-            if d > 0 then
-              bank[n][j].enveloped = true
-              if pre_enveloped ~= bank[n][j].enveloped then
-                cheat(n, bank[n].id)
-              end
-            end
-          end
-        end
-      else
-        local pre_enveloped = bank[n][focused_pad].enveloped
-        if bank[n][focused_pad].enveloped then
-          if d < 0 then
-            bank[n][focused_pad].enveloped = false
-            if pre_enveloped ~= bank[n][bank[n].id].enveloped then
-              if bank[n].focus_hold == false then
-                cheat(n, bank[n].id)
-              end
-            end
-          end
-        else
-          if d > 0 then
-            bank[n][focused_pad].enveloped = true
-            if pre_enveloped ~= bank[n][focused_pad].enveloped then
-              if bank[n].focus_hold == false then
-                cheat(n, bank[n].id)
-              end
-            end
+            bank[n][focused_pad].envelope_loop = false
           end
         end
       end
-    elseif page.levels_sel == 2 then
+
+    elseif page.levels_sel == 3 then
       if key1_hold or grid.alt == 1 then
         for j = 1,16 do
           if bank[n][j].enveloped then
@@ -740,11 +740,12 @@ function encoder_actions.init(n,d)
         end
       else
         if bank[n][focused_pad].enveloped then
-          bank[n][focused_pad].envelope_time = util.explin(0.1,60,0.1,60,bank[n][focused_pad].envelope_time)
-          bank[n][focused_pad].envelope_time = util.clamp(bank[n][focused_pad].envelope_time+d/10,0.1,60)
-          bank[n][focused_pad].envelope_time = util.linexp(0.1,60,0.1,60,bank[n][focused_pad].envelope_time)
+          bank[n][focused_pad].envelope_time = util.explin(0.05,60,0.05,60,bank[n][focused_pad].envelope_time)
+          bank[n][focused_pad].envelope_time = util.clamp(bank[n][focused_pad].envelope_time+d/10,0.05,60)
+          bank[n][focused_pad].envelope_time = util.linexp(0.05,60,0.05,60,bank[n][focused_pad].envelope_time)
         end
       end
+      env_counter[n].time = (bank[n][focused_pad].envelope_time/(bank[n][focused_pad].level/0.05))
     end
   end
   if menu == 4 then

--- a/lib/euclid.lua
+++ b/lib/euclid.lua
@@ -24,6 +24,7 @@ function euclid.trig(target)
       end
       cheat(target,euclid.rotate_pads(euclid.track[target].pos + euclid.track[target].pad_offset))
     end
+    grid_dirty = true
   end
 end
 

--- a/lib/euclid.lua
+++ b/lib/euclid.lua
@@ -113,26 +113,26 @@ end
 
 function euclid.savestate()
   local collection = params:get("collection")
-  local dirname = _path.data.."cheat_codes/rytm/"
+  local dirname = _path.data.."cheat_codes2/rytm/"
   if os.rename(dirname, dirname) == nil then
     os.execute("mkdir " .. dirname)
   end
   
-  local dirname = _path.data.."cheat_codes/rytm/collection-"..collection.."/"
+  local dirname = _path.data.."cheat_codes2/rytm/collection-"..collection.."/"
   if os.rename(dirname, dirname) == nil then
     os.execute("mkdir " .. dirname)
   end
 
   for i = 1,3 do
-    tab.save(euclid.track[i],_path.data .. "cheat_codes/rytm/collection-"..collection.."/"..i..".data")
+    tab.save(euclid.track[i],_path.data .. "cheat_codes2/rytm/collection-"..collection.."/"..i..".data")
   end
 end
 
 function euclid.loadstate()
   local collection = params:get("collection")
   for i = 1,3 do
-    if tab.load(_path.data .. "cheat_codes/rytm/collection-"..collection.."/"..i..".data") ~= nil then
-      euclid.track[i] = tab.load(_path.data .. "cheat_codes/rytm/collection-"..collection.."/"..i..".data")
+    if tab.load(_path.data .. "cheat_codes2/rytm/collection-"..collection.."/"..i..".data") ~= nil then
+      euclid.track[i] = tab.load(_path.data .. "cheat_codes2/rytm/collection-"..collection.."/"..i..".data")
     end
   end
   euclid.reset_pattern()

--- a/lib/grid_actions.lua
+++ b/lib/grid_actions.lua
@@ -527,7 +527,7 @@ function grid_actions.init(x,y,z)
               if key1_hold == true then key1_hold = false end
               if y == 4 then
                 menu = 2
-                page.loops_sel = math.floor((x/4)-1)
+                page.loops_sel = math.floor((x/4))
               end
               redraw()
             end

--- a/lib/grid_actions.lua
+++ b/lib/grid_actions.lua
@@ -533,11 +533,7 @@ function grid_actions.init(x,y,z)
             end
           elseif bank[i].alt_lock or grid.alt == 1 then
             if y == 2 then
-              if grid_pat[math.ceil(x/4)].playmode == 3 or grid_pat[math.ceil(x/4)].playmode == 4 then
-                clock.run(random_grid_pat, math.ceil(x/4), 3)
-              else
-                random_grid_pat(math.ceil(x/4),3)
-              end
+              random_grid_pat(math.ceil(x/4),3)
             end
             if y == 3 then
               page.arp_page_sel = i

--- a/lib/grid_actions.lua
+++ b/lib/grid_actions.lua
@@ -20,7 +20,7 @@ function grid_actions.init(x,y,z)
   if grid_page == 0 then
     
     for i = 1,3 do
-      if grid.alt == 1 then
+      if grid.alt then
         if x == 1+(5*(i-1)) and y == 1 and z == 1 then
           bank[i].focus_hold = not bank[i].focus_hold
         end
@@ -30,7 +30,7 @@ function grid_actions.init(x,y,z)
     for i = 1,3 do
       if z == 1 and x > 0 + (5*(i-1)) and x <= 4 + (5*(i-1)) and y >=5 then
         if bank[i].focus_hold == false then
-          if grid.alt == 0 then
+          if not grid.alt then
             selected[i].x = x
             selected[i].y = y
             selected[i].id = (math.abs(y-9)+((x-1)*4))-(20*(i-1))
@@ -83,14 +83,14 @@ function grid_actions.init(x,y,z)
             arps.momentary(i, released_pad, "off")
           end
         else
-          if grid.alt == 0 then
+          if not grid.alt then
             bank[i].focus_pad = (math.abs(y-9)+((x-1)*4))-(20*(i-1))
             --[[
             if tracker[i].recording then
               add_to_tracker(i,{bank[i].focus_pad,0.25,"next"})
             end
             --]]
-          elseif grid.alt == 1 then
+          elseif grid.alt then
             if not pad_clipboard then
               pad_clipboard = {}
               bank[i].focus_pad = (math.abs(y-9)+((x-1)*4))-(20*(i-1))
@@ -182,12 +182,12 @@ function grid_actions.init(x,y,z)
       for i = 1,3 do
         if z == 0 and x == (k+1)+(5*(i-1)) and y<=k then
           if grid_pat[i].quantize == 0 then -- still relevant
-            if bank[i].alt_lock and grid.alt == 0 then
+            if bank[i].alt_lock and not grid.alt then
               if grid_pat[i].play == 1 then
                 grid_pat[i].overdub = grid_pat[i].overdub == 0 and 1 or 0
               end
             else
-              if grid.alt == 1 then -- still relevant
+              if grid.alt then -- still relevant
                 grid_pat[i]:rec_stop()
                 grid_pat[i]:stop()
                 --grid_pat[i].external_start = 0
@@ -222,7 +222,7 @@ function grid_actions.init(x,y,z)
               end
             end
           else
-            if grid.alt == 1 then
+            if grid.alt then
               grid_pat[i]:rec_stop()
               grid_pat[i]:stop()
               grid_pat[i].tightened_start = 0
@@ -250,7 +250,7 @@ function grid_actions.init(x,y,z)
         else
           a_p = arc_param[current] - 2
         end
-        if grid.alt == 1 then
+        if grid.alt then
           arc_pat[current][a_p]:rec_stop()
           arc_pat[current][a_p]:stop()
           arc_pat[current][a_p]:clear()
@@ -276,7 +276,7 @@ function grid_actions.init(x,y,z)
         which_bank = i
         local which_pad = bank[i].focus_hold == true and bank[i].focus_pad or bank[i].id
         bank[i][which_pad].loop = not bank[i][which_pad].loop
-        if bank[i].alt_lock or grid.alt == 1 then
+        if bank[i].alt_lock or grid.alt then
           for j = 1,16 do
             bank[i][j].loop = bank[i][which_pad].loop
           end
@@ -293,18 +293,18 @@ function grid_actions.init(x,y,z)
     end
     
     if x == 16 and y == 8 then
-      if grid.alt_pp == 1 then
-        grid.alt_pp = 0
-      end
-      if grid.alt_delay then
-        grid.alt_delay = false
-      end
-      grid.alt = z
+      -- if grid.alt_pp == 1 then
+      --   grid.alt_pp = 0
+      -- end
+      -- if grid.alt_delay then
+      --   grid.alt_delay = false
+      -- end
+      grid.alt = z == 1 and true or false
       arc.alt = z
       if menu == 11 then
-        if grid.alt == 1 then
+        if grid.alt then
           help_menu = "alt"
-        elseif grid.alt == 0 then
+        elseif not grid.alt then
           help_menu = "welcome"
         end
       end
@@ -316,8 +316,8 @@ function grid_actions.init(x,y,z)
       if x == 1 or x == 6 or x == 11 then
         local which_pad = nil
         local current = util.round(math.sqrt(math.abs(x-2)))
-        --if grid.alt == 0 then
-        if not bank[current].alt_lock and grid.alt == 0 then
+        --if not grid.alt then
+        if not bank[current].alt_lock and not grid.alt then
           if bank[current].focus_hold == false then
             --jump_live(current, bank[current].id, y, z)
             jump_clip(current, bank[current].id, y, z)
@@ -325,7 +325,7 @@ function grid_actions.init(x,y,z)
             --jump_live(current, bank[current].focus_pad, y, z)
             jump_clip(current, bank[current].focus_pad, y, z)
           end
-        elseif bank[current].alt_lock or grid.alt == 1 then
+        elseif bank[current].alt_lock or grid.alt then
           for j = 1,16 do
             --jump_live(current, j, y, z)
             jump_clip(current, j, y, z)
@@ -349,8 +349,8 @@ function grid_actions.init(x,y,z)
       for j = 2,12,5 do
         if x == j and y == i and z == 1 then
           local which_pad = nil
-          --if grid.alt == 0 then
-          if not bank[math.sqrt(math.abs(x-3))].alt_lock and grid.alt == 0 then
+          --if not grid.alt then
+          if not bank[math.sqrt(math.abs(x-3))].alt_lock and not grid.alt then
             local current = math.sqrt(math.abs(x-3))
             if bank[current].focus_hold == false then
               local old_mode = bank[current][bank[current].id].mode
@@ -365,7 +365,7 @@ function grid_actions.init(x,y,z)
                 change_mode(bank[current][bank[current].focus_pad], old_mode)
               end
             end
-          elseif bank[math.sqrt(math.abs(x-3))].alt_lock or grid.alt == 1 then
+          elseif bank[math.sqrt(math.abs(x-3))].alt_lock or grid.alt then
             for k = 1,16 do
               local current = math.sqrt(math.abs(x-3))
               local old_mode = bank[current][k].mode
@@ -410,7 +410,7 @@ function grid_actions.init(x,y,z)
     for i = 7,5,-1 do
       if x == 16 and z == 1 and y == i then
         toggle_buffer(8-y)
-        if grid.alt == 1 then
+        if grid.alt then
           buff_flush()
         end
         
@@ -424,7 +424,7 @@ function grid_actions.init(x,y,z)
     for i = 8,6,-1 do
       if x == 5 or x == 10 or x == 15 then
         if y == i then
-          if grid.alt == 0 then
+          if not grid.alt then
             if z == 1 then
               table.insert(arc_switcher[x/5],y)
               held_query[x/5] = #arc_switcher[x/5]
@@ -454,7 +454,7 @@ function grid_actions.init(x,y,z)
                 arc_switcher[x/5] = {}
               end
             end
-          elseif grid.alt == 1 then
+          elseif grid.alt then
             if y == 8 then
               -- sixteen_slices(x/5)
             elseif y == 7 then
@@ -473,7 +473,7 @@ function grid_actions.init(x,y,z)
           if bank[i].focus_hold == true then
             if x == i*5 then
               bank[i][bank[i].focus_pad].crow_pad_execute = (bank[i][bank[i].focus_pad].crow_pad_execute + 1)%2
-              if grid.alt == 1 then
+              if grid.alt then
                 for j = 1,16 do
                   bank[i][j].crow_pad_execute = bank[i][bank[i].focus_pad].crow_pad_execute
                 end
@@ -483,7 +483,7 @@ function grid_actions.init(x,y,z)
         end
       end
       if x == 5 or x == 10 or x == 15 then
-        if grid.alt == 0 then
+        if not grid.alt then
           bank[x/5].alt_lock = z == 1 and true or false
         else
           if z == 1 then
@@ -499,30 +499,32 @@ function grid_actions.init(x,y,z)
         if z == 1 and x == k+(5*(i-1)) and y == k then
           
           ---
-          --if grid.alt == 0 then
-          if not bank[i].alt_lock and grid.alt == 0 then
+          --if not grid.alt then
+          if not bank[i].alt_lock and not grid.alt then
             if y == 3 then
 
-              if not arp[i].enabled then
-                arp[i].enabled = true
-              elseif not arp[i].hold then
-                if #arp[i].notes > 0 then
-                  arp[i].hold = true
-                else
-                  arp[i].enabled = false
-                end
-              else
-                if #arp[i].notes > 0 then
-                  if arp[i].playing == true then
-                    arp[i].pause = true
-                    arp[i].playing = false
-                  else
-                    arp[i].step = arp[i].start_point-1
-                    arp[i].pause = false
-                    arp[i].playing = true
-                  end
-                end
-              end
+              grid_actions.arp_handler(i)
+
+              -- if not arp[i].enabled then
+              --   arp[i].enabled = true
+              -- elseif not arp[i].hold then
+              --   if #arp[i].notes > 0 then
+              --     arp[i].hold = true
+              --   else
+              --     arp[i].enabled = false
+              --   end
+              -- else
+              --   if #arp[i].notes > 0 then
+              --     if arp[i].playing == true then
+              --       arp[i].pause = true
+              --       arp[i].playing = false
+              --     else
+              --       arp[i].step = arp[i].start_point-1
+              --       arp[i].pause = false
+              --       arp[i].playing = true
+              --     end
+              --   end
+              -- end
             else
               if key1_hold == true then key1_hold = false end
               if y == 4 then
@@ -531,21 +533,12 @@ function grid_actions.init(x,y,z)
               end
               redraw()
             end
-          elseif bank[i].alt_lock or grid.alt == 1 then
+          elseif bank[i].alt_lock or grid.alt then
             if y == 2 then
               random_grid_pat(math.ceil(x/4),3)
             end
             if y == 3 then
-              page.arp_page_sel = i
-              arp[i].hold = not arp[i].hold
-              if not arp[i].hold then
-                arps.clear(i)
-              end
-              arp[i].enabled = false
-
-
-
-              --arp[i].pause = not arp[i].pause
+              grid_actions.kill_arp(i)
             end
             if y == 4 then
               local current = math.floor(x/5)+1
@@ -581,7 +574,7 @@ function grid_actions.init(x,y,z)
               else
                 --if there's a pattern saved there...
                 if pattern_saver[current].saved[9-y] == 1 then
-                  if grid.alt_pp == 0 then
+                  if not grid.alt then
                     step_seq[current][step_seq[current].held].assigned_to = 9-y
                   end
                 end
@@ -595,7 +588,7 @@ function grid_actions.init(x,y,z)
                   -- print("killing save "..pattern_saver[math.floor(x/5)+1].clock)
                 end
                 pattern_saver[math.floor(x/5)+1].active = false
-                if grid.alt_pp == 0 and saved_pat == 1 then
+                if not grid.alt and saved_pat == 1 then
                   if pattern_saver[current].saved[9-y] == 1 then
                     pattern_saver[current].load_slot = 9-y
                     test_load((9-y)+(8*(current-1)),current)
@@ -621,7 +614,7 @@ function grid_actions.init(x,y,z)
           if z == 1 and x == i and y == j then
             local current = math.floor(x/5)+1
             step_seq[current].held = 9-y
-            if grid.alt_pp == 1 then
+            if grid.alt then
               step_seq[current][step_seq[current].held].assigned_to = 0
             end
           elseif z == 0 and x == i and y == j then
@@ -630,7 +623,7 @@ function grid_actions.init(x,y,z)
           elseif z == 1 and x == i+1 and y == j then
             local current = math.floor(x/5)+1
             step_seq[current].held = (9-y)+8
-            if grid.alt_pp == 1 then
+            if grid.alt then
               step_seq[current][step_seq[current].held].assigned_to = 0
             end
           elseif z == 0 and x == i+1 and y == j then
@@ -649,7 +642,7 @@ function grid_actions.init(x,y,z)
             else
               step_seq[current][step_seq[current].held].meta_meta_duration = 9-y
             end
-            if grid.alt_pp == 1 then
+            if grid.alt then
               for k = 1,16 do
                 step_seq[current][k].meta_meta_duration = 9-y
               end
@@ -661,7 +654,7 @@ function grid_actions.init(x,y,z)
       for i = 7,5,-1 do
         if x == 16 and y == i and z == 1 then
           if step_seq[8-i].held == 0 then
-            if grid.alt_pp == 1 then
+            if grid.alt then
               step_seq[8-i].current_step = step_seq[8-i].start_point
               step_seq[8-i].meta_step = 1
               step_seq[8-i].meta_meta_step = 1
@@ -679,7 +672,7 @@ function grid_actions.init(x,y,z)
       
       
       if x == 16 and y == 8 then
-        grid.alt_pp = z
+        grid.alt = z == 1 and true or false
         redraw()
         -- grid_redraw()
       end
@@ -768,7 +761,8 @@ function grid_actions.init(x,y,z)
           del.set_value(6-y, x-3, "feedback")
         end
       elseif x == 9 then
-        if grid.alt_delay then
+        -- if grid.alt_delay then
+        if grid.alt then
           del.quick_action(6-y, "clear")
         end
         del.quick_action(6-y,"feedback mute")
@@ -776,7 +770,8 @@ function grid_actions.init(x,y,z)
     elseif y == 1 or y == 8 then
       if x >= 10 and x <=14 then
         if z == 1 then
-          del.set_value(y == 8 and 1 or 2,x-9,grid.alt_delay == true and "send all" or "send")
+          -- del.set_value(y == 8 and 1 or 2,x-9,grid.alt_delay == true and "send all" or "send")
+          del.set_value(y == 8 and 1 or 2,x-9,grid.alt == true and "send all" or "send")
         end
       elseif x == 15 then
         del.quick_action(y == 8 and 1 or 2,"send mute")
@@ -794,7 +789,8 @@ function grid_actions.init(x,y,z)
             delay[target].saver_active = true
             clock.run(del.build_bundle,target,bundle)
           elseif saved_already then
-            if grid.alt_delay then
+            -- if grid.alt_delay then
+            if grid.alt then
               del.clear_bundle(target,bundle)
             else
               del.restore_bundle(target,bundle)
@@ -823,25 +819,43 @@ function grid_actions.init(x,y,z)
       end
     end
 
+    if x == 12 and y == 2 then
+      if z == 1 then
+        if grid.alt or bank[delay_grid.bank].alt_lock then
+          grid_actions.kill_arp(delay_grid.bank)
+        elseif not grid.alt and not bank[delay_grid.bank].alt_lock then
+          grid_actions.arp_handler(delay_grid.bank)
+        end
+      end
+    end
+
     if x >= 10 and x <= 13 and y >=3 and y <=6 then
       local id = delay_grid.bank
-      if z == 1 then
-        local xval = {9,4,-1}
-        selected[id].x = x - xval[id]
-        selected[id].y = y + 2
-        selected[id].id = (math.abs(selected[id].y-9)+((selected[id].x-1)*4))-(20*(id-1))
-        bank[id].id = selected[id].id
-        -- if (arp[id].hold or (menu == 9)) and grid_pat[id].rec == 0 and not arp[id].pause then
-        if (arp[id].enabled or (menu == 9)) and grid_pat[id].rec == 0 and not arp[id].pause then
-          arp[id].time = bank[id][bank[id].id].arp_time
-          arps.momentary(id, bank[id].id, "on")
+      if not grid.alt then
+        if z == 1 then
+          local xval = {9,4,-1}
+          selected[id].x = x - xval[id]
+          selected[id].y = y + 2
+          selected[id].id = (math.abs(selected[id].y-9)+((selected[id].x-1)*4))-(20*(id-1))
+          bank[id].id = selected[id].id
+          -- if (arp[id].hold or (menu == 9)) and grid_pat[id].rec == 0 and not arp[id].pause then
+          if (arp[id].enabled or (menu == 9)) and grid_pat[id].rec == 0 and not arp[id].pause then
+            arp[id].time = bank[id][bank[id].id].arp_time
+            arps.momentary(id, bank[id].id, "on")
+          else
+            cheat(id, bank[id].id)
+            grid_pattern_watch(id)
+          end
         else
-          cheat(id, bank[id].id)
-          grid_pattern_watch(id)
+          -- if not arp[id].hold then
+          if arp[id].enabled and not arp[id].hold then
+            local xval = {9,4,-1}
+            local released_pad = (math.abs((y + 2)-9)+(((x - xval[id])-1)*4))-(20*(id-1))
+            arps.momentary(id, released_pad, "off")
+          end
         end
       else
-        -- if not arp[id].hold then
-        if arp[id].enabled and not arp[id].hold then
+        if z == 1 then
           local xval = {9,4,-1}
           local released_pad = (math.abs((y + 2)-9)+(((x - xval[id])-1)*4))-(20*(id-1))
           arps.momentary(id, released_pad, "off")
@@ -850,14 +864,15 @@ function grid_actions.init(x,y,z)
     end
 
     if x == 16 and y == 8 then
-      grid.alt_delay = not grid.alt_delay
+      -- grid.alt_delay = not grid.alt_delay
+      grid.alt = not grid.alt
     end
 
   end
   
   if x == 16 and y == 1 and z == 1 then
     if grid_page == 0 then
-      if grid.alt == 0 then
+      if not grid.alt then
         grid_page = 1
         if menu == 11 then
           if grid_page == 1 then
@@ -869,30 +884,62 @@ function grid_actions.init(x,y,z)
         end
       else
         grid_page = 2
-        grid.alt_delay = true
-        grid.alt = 0
+        -- grid.alt_delay = true
+        grid.alt = true
+        -- grid.alt = 0
       end
     elseif grid_page == 1 then
-      if grid.alt_pp == 0 then
+      if not grid.alt then
         grid_page = 2
       else
         grid_page = 0
-        grid.alt = 1
-        grid.alt_pp = 0
+        -- grid.alt = true
       end
     elseif grid_page == 2 then
-      if not grid.alt_delay then
+      -- if not grid.alt_delay then
+      if not grid.alt then
         grid_page = 0
       else
         grid_page = 1
-        grid.alt_pp = 1
-        grid.alt_delay = false
+        -- grid.alt_delay = false
       end
     end
   end
 
   grid_dirty = true
     
+end
+
+function grid_actions.arp_handler(i)
+  if not arp[i].enabled then
+    arp[i].enabled = true
+  elseif not arp[i].hold then
+    if #arp[i].notes > 0 then
+      arp[i].hold = true
+    else
+      arp[i].enabled = false
+    end
+  else
+    if #arp[i].notes > 0 then
+      if arp[i].playing == true then
+        arp[i].pause = true
+        arp[i].playing = false
+      else
+        arp[i].step = arp[i].start_point-1
+        arp[i].pause = false
+        arp[i].playing = true
+      end
+    end
+  end
+end
+
+function grid_actions.kill_arp(i)
+  page.arp_page_sel = i
+  arp[i].hold = not arp[i].hold
+  if not arp[i].hold then
+    arps.clear(i)
+  end
+  arp[i].enabled = false
 end
 
 return grid_actions

--- a/lib/grid_actions.lua
+++ b/lib/grid_actions.lua
@@ -456,7 +456,7 @@ function grid_actions.init(x,y,z)
             end
           elseif grid.alt == 1 then
             if y == 8 then
-              sixteen_slices(x/5)
+              -- sixteen_slices(x/5)
             elseif y == 7 then
               rec_to_pad(x/5)
             elseif y == 6 then

--- a/lib/main_menu.lua
+++ b/lib/main_menu.lua
@@ -28,7 +28,7 @@ function main_menu.init()
       , " euclid"
       , " arp"
       , " rnd"
-      , " ?"
+      , " "
       }
       screen.text(page.main_sel == i and (">"..options[i]) or options[i])
     end
@@ -94,7 +94,7 @@ function main_menu.init()
       -- local loops_to_screen_options = {"a", "b", "c"}
       -- screen.text(loops_to_screen_options[i]..""..which_pad)
 
-      if grid.alt == 0 then
+      if not grid.alt then
         local loops_to_screen_options = {"a", "b", "c"}
         screen.text(loops_to_screen_options[i]..""..which_pad)
       else
@@ -139,7 +139,7 @@ function main_menu.init()
         end
         screen.move(0,8+(i*14))
         screen.level(page.loops_sel == i and 15 or 3)
-        if grid.alt == 0 then
+        if not grid.alt then
           local loops_to_screen_options = {"a", "b", "c"}
           screen.text(loops_to_screen_options[i]..""..focused_pad)
         else
@@ -155,7 +155,7 @@ function main_menu.init()
         screen.move(15,8+(i*14))
         local id = page.loops_sel
         local focused_pad = nil
-        -- if grid.alt == 1 then
+        -- if grid.alt then
         --   screen.move(0,20)
         --   screen.level(6)
         --   screen.text("(grid-ALT sets offset for all)")
@@ -167,7 +167,7 @@ function main_menu.init()
           focused_pad = bank[i].focus_pad
         end
         -- if page.loops_sel == i-1 then
-        --   if page.loops_sel < 3 and focused_pad == 16 and grid.alt == 0 then
+        --   if page.loops_sel < 3 and focused_pad == 16 and not grid.alt then
         --     screen.move(0,20)
         --     screen.level(6)
         --     screen.text("(pad 16 overwrites bank!)")
@@ -180,7 +180,7 @@ function main_menu.init()
         -- end
         screen.move(0,8+(i*14))
         screen.level(page.loops_sel == i and 15 or 3)
-        if grid.alt == 0 then
+        if not grid.alt then
           local loops_to_screen_options = {"a", "b", "c"}
           screen.text(loops_to_screen_options[i]..""..focused_pad)
         else
@@ -249,13 +249,13 @@ function main_menu.init()
       screen.move(10+(i*20),64)
       screen.level(level_options[page.levels_sel+1] == "levels" and 15 or 3)
       local level_to_screen_options = {"a", "b", "c"}
-      if key1_hold or grid.alt == 1 or bank[i].alt_lock then
+      if key1_hold or grid.alt or bank[i].alt_lock then
         screen.text("("..level_to_screen_options[i]..")")
       else
         screen.text(level_to_screen_options[i]..""..focused_pad)
       end
       screen.move(35+(20*(i-1)),57)
-      local level_to_screen = ((key1_hold or grid.alt == 1 or bank[i].alt_lock) and util.linlin(0,2,0,40,bank[i].global_level) or util.linlin(0,2,0,40,bank[i][focused_pad].level))
+      local level_to_screen = ((key1_hold or grid.alt or bank[i].alt_lock) and util.linlin(0,2,0,40,bank[i].global_level) or util.linlin(0,2,0,40,bank[i][focused_pad].level))
       screen.line(35+(20*(i-1)),57-level_to_screen)
       screen.close()
       screen.stroke()
@@ -282,7 +282,7 @@ function main_menu.init()
       -- screen.text("time")
       screen.move(85,34+((i)*10))
       local envelope_to_screen_options = {"a", "b", "c"}
-      if key1_hold or grid.alt == 1 or bank[i].alt_lock then
+      if key1_hold or grid.alt or bank[i].alt_lock then
         screen.text("("..envelope_to_screen_options[i]..")")
       else
         screen.text(envelope_to_screen_options[i]..""..focused_pad)
@@ -316,7 +316,7 @@ function main_menu.init()
       screen.move(pan_to_screen,35+(10*(i-1)))
       local pan_to_screen_options = {"a", "b", "c"}
       screen.level(15)
-      if key1_hold or grid.alt == 1 then
+      if key1_hold or grid.alt then
         screen.text("("..pan_to_screen_options[i]..")")
       else
         screen.text(pan_to_screen_options[i]..""..focused_pad)
@@ -334,7 +334,7 @@ function main_menu.init()
       screen.move(17+((i-1)*45),25)
       screen.level(15)
       local filters_to_screen_options = {"a", "b", "c"}
-      if key1_hold or grid.alt == 1 then
+      if key1_hold or grid.alt then
         screen.text_center(filters_to_screen_options[i]..""..bank[i].id)
       else
         screen.text_center("("..filters_to_screen_options[i]..")")
@@ -919,6 +919,12 @@ function main_menu.init()
       screen.text_center(dots)
       screen.font_size(8)
     end
+  elseif menu == "save screen" then
+    screen.level(15)
+    screen.move(62,43)
+    screen.font_size(40)
+    screen.text_center("saved!")
+    screen.font_size(8)
   elseif menu == "load fail screen" then
     screen.level(15)
     screen.move(62,30)
@@ -928,7 +934,7 @@ function main_menu.init()
     screen.font_size(15)
     screen.text_center("try another...")
     screen.font_size(8)
-  elseif menu == "save screen" then
+  elseif menu == "overwrite screen" then
     screen.level(15)
     screen.move(62,15)
     screen.font_size(10)
@@ -942,14 +948,35 @@ function main_menu.init()
       screen.text_center("K2 or K3 to cancel")
     end
     screen.font_size(8)
-  elseif menu == "canceled screen" then
+  elseif menu == "delete screen" then
+    screen.level(15)
+    screen.move(62,15)
+    screen.font_size(10)
+    screen.text_center("deleting collection")
+    screen.font_size(40)
+    screen.move(62,50)
+    screen.text_center(dots)
+    screen.move(62,64)
+    screen.font_size(10)
+    if dots ~= "deleted!" then
+      screen.text_center("K2 or K3 to cancel")
+    end
+    screen.font_size(8)
+  elseif menu == "canceled overwrite screen" or menu == "canceled delete screen" then
     screen.level(15)
     screen.move(62,30)
     screen.font_size(20)
-    screen.text_center("save")
+    screen.text_center(menu == "canceled overwrite screen" and "overwrite" or "delete")
     screen.move(62,50)
     screen.text_center("canceled")
   end
+end
+
+function save_screen(text)
+  menu = "save screen"
+  named_savestate(text)
+  clock.sleep(0.75)
+  menu = 1
 end
 
 function load_screen()
@@ -979,9 +1006,9 @@ function load_fail_screen()
   end
 end
 
-function save_screen(text)
+function overwrite_screen(text)
   dots = "3"
-  menu = "save screen"
+  menu = "overwrite screen"
   clock.sleep(0.75)
   dots = "2"
   clock.sleep(0.75)
@@ -994,7 +1021,27 @@ function save_screen(text)
 end
 
 function canceled_save()
-  menu = "canceled screen"
+  menu = "canceled overwrite screen"
+  clock.sleep(0.75)
+  menu = 1
+end
+
+function delete_screen(text)
+  dots = "3"
+  menu = "delete screen"
+  clock.sleep(0.75)
+  dots = "2"
+  clock.sleep(0.75)
+  dots = "1"
+  clock.sleep(0.75)
+  dots = "(x_x)"
+  clock.sleep(0.33)
+  named_delete(text)
+  menu = 1
+end
+
+function canceled_delete()
+  menu = "canceled delete screen"
   clock.sleep(0.75)
   menu = 1
 end

--- a/lib/main_menu.lua
+++ b/lib/main_menu.lua
@@ -249,13 +249,13 @@ function main_menu.init()
       screen.move(10+(i*20),64)
       screen.level(level_options[page.levels_sel+1] == "levels" and 15 or 3)
       local level_to_screen_options = {"a", "b", "c"}
-      if key1_hold or grid.alt == 1 then
+      if key1_hold or grid.alt == 1 or bank[i].alt_lock then
         screen.text("("..level_to_screen_options[i]..")")
       else
         screen.text(level_to_screen_options[i]..""..focused_pad)
       end
       screen.move(35+(20*(i-1)),57)
-      local level_to_screen = ((key1_hold or grid.alt == 1) and util.linlin(0,2,0,40,bank[i].global_level) or util.linlin(0,2,0,40,bank[i][focused_pad].level))
+      local level_to_screen = ((key1_hold or grid.alt == 1 or bank[i].alt_lock) and util.linlin(0,2,0,40,bank[i].global_level) or util.linlin(0,2,0,40,bank[i][focused_pad].level))
       screen.line(35+(20*(i-1)),57-level_to_screen)
       screen.close()
       screen.stroke()
@@ -282,7 +282,7 @@ function main_menu.init()
       -- screen.text("time")
       screen.move(85,34+((i)*10))
       local envelope_to_screen_options = {"a", "b", "c"}
-      if key1_hold or grid.alt == 1 then
+      if key1_hold or grid.alt == 1 or bank[i].alt_lock then
         screen.text("("..envelope_to_screen_options[i]..")")
       else
         screen.text(envelope_to_screen_options[i]..""..focused_pad)

--- a/lib/main_menu.lua
+++ b/lib/main_menu.lua
@@ -1,5 +1,7 @@
 local main_menu = {}
 
+local dots = "."
+
 function main_menu.init()
   if menu == 1 then
     screen.move(0,10)
@@ -875,7 +877,81 @@ function main_menu.init()
     screen.move(0,64)
     screen.text("...")
   
+  elseif menu == "load screen" then
+    screen.level(15)
+    screen.move(62,15)
+    screen.font_size(10)
+    if collection_loaded then
+      screen.text_center("loading collection "..selected_coll)
+      screen.font_size(40)
+      screen.move(62,50)
+      screen.text_center(dots)
+      screen.font_size(8)
+    else
+      screen.move(62,40)
+      screen.font_size(20)
+      screen.text_center("no data!")
+      screen.font_size(8)
+    end
+  elseif menu == "save screen" then
+    screen.level(15)
+    screen.move(62,15)
+    screen.font_size(10)
+    screen.text_center("saving collection "..tonumber(string.format("%.0f",params:get("collection"))))
+    screen.font_size(40)
+    screen.move(62,50)
+    screen.text_center(dots)
+    screen.move(10,64)
+    screen.font_size(10)
+    if dots ~= "saved!" then
+      screen.text("K2 or K3 to cancel")
+    end
+    screen.font_size(8)
+  elseif menu == "canceled screen" then
+    screen.level(15)
+    screen.move(62,30)
+    screen.font_size(20)
+    screen.text_center("save")
+    screen.move(62,50)
+    screen.text_center("canceled")
   end
+end
+
+function load_screen()
+  dots = "..."
+  menu = "load screen"
+  clock.sleep(0.33)
+  dots = ".."
+  clock.sleep(0.33)
+  dots = "."
+  clock.sleep(0.33)
+  dots = "ready!"
+  clock.sleep(0.75)
+  menu = 1
+  if not collection_loaded then
+    _norns.key(1,1)
+    _norns.key(1,0)
+  end
+end
+
+function save_screen()
+  dots = "3"
+  menu = "save screen"
+  clock.sleep(0.75)
+  dots = "2"
+  clock.sleep(0.75)
+  dots = "1"
+  clock.sleep(0.75)
+  dots = "saved!"
+  clock.sleep(0.33)
+  savestate()
+  menu = 1
+end
+
+function canceled_save()
+  menu = "canceled screen"
+  clock.sleep(0.75)
+  menu = 1
 end
 
 return main_menu

--- a/lib/rnd_actions.lua
+++ b/lib/rnd_actions.lua
@@ -72,7 +72,8 @@ end
 
 function rnd.restore_default(t,i)
     if rnd[t][i].param == "rate slew" then
-        softcut.rate_slew_time(t+1,params:get("rate slew time "..t))
+        -- softcut.rate_slew_time(t+1,params:get("rate slew time "..t))
+        softcut.rate_slew_time(t+1,bank[t][bank[t].id].rate_slew)
     elseif rnd[t][i].param == "pan" then
         softcut.pan(t+1,bank[t][bank[t].id].pan)
     elseif rnd[t][i].param == "delay send" then
@@ -89,7 +90,10 @@ end
 function rnd.rate_slew(t,i)
     local min = util.round(rnd[t][i].rate_slew_min * 1000)
     local max = util.round(rnd[t][i].rate_slew_max * 1000)
-    local random_slew = math.random(min,max)/10000
+    local random_slew = math.random(min,max)/1000
+    if rnd[t][i].mode == "destructive" then
+      bank[t][bank[t].id].rate_slew = random_slew
+    end
     softcut.rate_slew_time(t+1,random_slew)
 end
 
@@ -101,8 +105,6 @@ function rnd.pan(t,i)
     bank[t][bank[t].id].pan = rand_pan
   end
   softcut.pan(t+1,rand_pan)
-  -- rightangleslice.actions[3]['123'][1](bank[t][bank[t].id])
-  -- rightangleslice.actions[3]['123'][2](bank[t][bank[t].id],t)
 end
 
 function rnd.rate(t,i)
@@ -135,6 +137,7 @@ function rnd.loop(t)
         bank[t][bank[t].id].loop = false
         softcut.loop(t+1,0)
     end
+    grid_dirty = true
 end
 
 function rnd.delay_send(t,i)
@@ -143,6 +146,19 @@ function rnd.delay_send(t,i)
         bank[t][j].left_delay_level = delay_send
         bank[t][j].right_delay_level = delay_send
     end
+    softcut.level_slew_time(5,1)
+    softcut.level_slew_time(6,1)
+    if bank[t][bank[t].id].left_delay_thru then
+      softcut.level_cut_cut(t+1,5,bank[t][bank[t].id].left_delay_level)
+    else
+      softcut.level_cut_cut(t+1,5,(bank[t][bank[t].id].left_delay_level*bank[t][bank[t].id].level)*bank[t].global_level)
+    end
+    if bank[t][bank[t].id].right_delay_thru then
+      softcut.level_cut_cut(t+1,6,bank[t][bank[t].id].right_delay_level)
+    else
+      softcut.level_cut_cut(t+1,6,(bank[t][bank[t].id].right_delay_level*bank[t][bank[t].id].level)*bank[t].global_level)
+    end
+    grid_dirty = true
 end
 
 function rnd.offset(t,i)

--- a/lib/rnd_actions.lua
+++ b/lib/rnd_actions.lua
@@ -194,26 +194,26 @@ end
 
 function rnd.savestate()
   local collection = params:get("collection")
-  local dirname = _path.data.."cheat_codes/rnd/"
+  local dirname = _path.data.."cheat_codes2/rnd/"
   if os.rename(dirname, dirname) == nil then
     os.execute("mkdir " .. dirname)
   end
   
-  local dirname = _path.data.."cheat_codes/rnd/collection-"..collection.."/"
+  local dirname = _path.data.."cheat_codes2/rnd/collection-"..collection.."/"
   if os.rename(dirname, dirname) == nil then
     os.execute("mkdir " .. dirname)
   end
 
   for i = 1,3 do
-    tab.save(rnd[i],_path.data .. "cheat_codes/rnd/collection-"..collection.."/"..i..".data")
+    tab.save(rnd[i],_path.data .. "cheat_codes2/rnd/collection-"..collection.."/"..i..".data")
   end
 end
 
 function rnd.loadstate()
   local collection = params:get("collection")
   for i = 1,3 do
-    if tab.load(_path.data .. "cheat_codes/rnd/collection-"..collection.."/"..i..".data") ~= nil then
-      rnd[i] = tab.load(_path.data .. "cheat_codes/rnd/collection-"..collection.."/"..i..".data")
+    if tab.load(_path.data .. "cheat_codes2/rnd/collection-"..collection.."/"..i..".data") ~= nil then
+      rnd[i] = tab.load(_path.data .. "cheat_codes2/rnd/collection-"..collection.."/"..i..".data")
       for j = 1,#rnd[i] do
         rnd[i][j].clock = nil
         if rnd[i][j].playing then

--- a/lib/start_up.lua
+++ b/lib/start_up.lua
@@ -77,7 +77,7 @@ function start_up.init()
   params:add_separator("clips")
   
   for i = 1,3 do
-    params:add_file("clip "..i.." sample", "clip "..i.." sample")
+    params:add_file("clip "..i.." sample", "clip "..i.." sample", "/home/we/dust/audio/")
     params:set_action("clip "..i.." sample", function(file) load_sample(file,i) end)
   end
 

--- a/lib/start_up.lua
+++ b/lib/start_up.lua
@@ -77,7 +77,7 @@ function start_up.init()
   params:add_separator("clips")
   
   for i = 1,3 do
-    params:add_file("clip "..i.." sample", "clip "..i.." sample", "/home/we/dust/audio/")
+    params:add_file("clip "..i.." sample", "clip "..i.." sample")
     params:set_action("clip "..i.." sample", function(file) load_sample(file,i) end)
   end
 
@@ -278,9 +278,9 @@ function start_up.init()
     params:set_action("level "..i, function(x)
       bank[i][bank[i].id].level = x
       if not bank[i][bank[i].id].enveloped then
-        softcut.level(i+1,x)
-        softcut.level_cut_cut(i+1,5,util.linlin(-1,1,0,1,bank[i][bank[i].id].pan)*(bank[i][bank[i].id].left_delay_level*bank[i][bank[i].id].level))
-        softcut.level_cut_cut(i+1,6,util.linlin(-1,1,1,0,bank[i][bank[i].id].pan)*(bank[i][bank[i].id].right_delay_level*bank[i][bank[i].id].level))
+        softcut.level(i+1,x*bank[i].global_level)
+        softcut.level_cut_cut(i+1,5,(bank[i][bank[i].id].left_delay_level*bank[i][bank[i].id].level)*bank[i].global_level)
+        softcut.level_cut_cut(i+1,6,(bank[i][bank[i].id].right_delay_level*bank[i][bank[i].id].level)*bank[i].global_level)
       end
       redraw()
       end)
@@ -437,7 +437,7 @@ function start_up.init()
     params:add_control("delay L: ("..banks[i]..") send", "delay L: ("..banks[i]..") send", controlspec.new(0,1,'lin',0.1,0,""))
     params:set_action("delay L: ("..banks[i]..") send", function(x)
       if bank[i][bank[i].id].enveloped == false then
-        softcut.level_cut_cut(i+1,5,x*bank[i][bank[i].id].level)
+        softcut.level_cut_cut(i+1,5,(x*bank[i][bank[i].id].level)*bank[i].global_level)
       end
       for j = 1,16 do
         bank[i][j].left_delay_level = x
@@ -446,7 +446,7 @@ function start_up.init()
     params:add_control("delay R: ("..banks[i]..") send", "delay R: ("..banks[i]..") send", controlspec.new(0,1,'lin',0.1,0,""))
     params:set_action("delay R: ("..banks[i]..") send", function(x)
       if bank[i][bank[i].id].enveloped == false then
-        softcut.level_cut_cut(i+1,6,x*bank[i][bank[i].id].level)
+        softcut.level_cut_cut(i+1,6,(x*bank[i][bank[i].id].level)*bank[i].global_level)
       end
       for j = 1,16 do
         bank[i][j].right_delay_level = x

--- a/lib/zilchmos.lua
+++ b/lib/zilchmos.lua
@@ -71,7 +71,7 @@ function zilchmos.level_inc( pad, delta )
   if not bank[which_bank].alt_lock and grid.alt == 0 then
     pad.level = util.clamp( pad.level + delta, 0, 2 )
   else
-    if pad.pad_id == 1 then
+    if pad.pad_id == 1 then -- only do this once...
       bank[which_bank].global_level = util.clamp( bank[which_bank].global_level + delta, 0, 2)
     end
   end

--- a/lib/zilchmos.lua
+++ b/lib/zilchmos.lua
@@ -30,11 +30,11 @@ function zilchmos.init(k,i)
   local sc_action = z.actions[k][finger][2]
 
   -- here's where we call the action
-  --if grid.alt == 0 then
-  if not b.alt_lock and grid.alt == 0 then
+  --if not grid.alt then
+  if not b.alt_lock and not grid.alt then
     p_action( b[p] )
     --trackers.inherit(which_bank,p)
-  elseif b.alt_lock or grid.alt == 1 then
+  elseif b.alt_lock or grid.alt then
     z.map( p_action, b ) -- or map it over the whole bank
   end
   if not b.focus_hold then
@@ -68,7 +68,7 @@ function z.slew_add( pad ) z.slew( pad, "add" ) end
 -- core pad modifiers
 
 function zilchmos.level_inc( pad, delta )
-  if not bank[which_bank].alt_lock and grid.alt == 0 then
+  if not bank[which_bank].alt_lock and not grid.alt then
     pad.level = util.clamp( pad.level + delta, 0, 2 )
   else
     if pad.pad_id == 1 then -- only do this once...

--- a/lib/zilchmos.lua
+++ b/lib/zilchmos.lua
@@ -151,6 +151,9 @@ function zilchmos.start_random( pad )
     else
       min_start = math.floor(rec.start_point * 100) -- this sucks...
     end
+  elseif pad.mode == 2 then
+    max_end = math.floor(pad.end_point * 100)
+    min_start = math.floor(clip[pad.clip].min * 100)
   else
     --duration = math.modf(clip[pad.clip].sample_length)
     duration = pad.mode == 1 and 8 or math.modf(clip[pad.clip].sample_length)
@@ -179,6 +182,9 @@ function zilchmos.end_random( pad )
     else
       min_start = math.floor(rec.start_point * 100)
     end
+  elseif pad.mode == 2 then
+    max_end = math.floor(clip[pad.clip].max * 100)
+    min_start = math.floor(pad.start_point * 100)
   else
     duration = util.round(clip[pad.clip].sample_length)
     max_end = math.floor(((duration*pad.clip)+1) * 100)
@@ -222,6 +228,17 @@ function zilchmos.start_end_random( pad )
       else
         case2(8)
       end
+    end
+  elseif pad.mode == 2 then
+    local s_p = math.floor(clip[pad.clip].min * 100)
+    local e_p = math.floor(clip[pad.clip].max * 100)
+    local j = math.random(s_p, e_p) / 100
+    if j + current_difference >= clip[pad.clip].max then
+      pad.end_point = clip[pad.clip].max
+      pad.start_point = pad.end_point - current_difference
+    else
+      pad.start_point = j
+      pad.end_point = pad.start_point + current_difference
     end
   else
     case2(pad.mode == 1 and 8 or math.modf(clip[pad.clip].sample_length))


### PR DESCRIPTION
## UI improvements

continuing the work discussed in #10:
- [loops] page now is navigable with e1
- k3 on any lane to swap b/w loop points, rate + slew, and buffer management (buffer + offset)
- k1 + k3 on any bank lane to toggle looping on/off for that pad
- k1 + k3 on live buffer to toggle rec on/off
- k1 + e1 on loop play to move window
- k1 + e1 on loop edit to change bank
- k1 + e1 on live buffer edit to change live buffer

## levels improvements

### global level
- introduced a global level for each bank, which allows entire banks to be faded in/out without destroying their individual pad's level settings
- k1 hold on [levels] page will display global level
- k1 + e1/2/3 on global level will change global level
- grid alt + zilchmo 2 affects global level (zilchmo 2 w/o grid alt affects pad level)

### envelopes
addresses #13 
- introduced two new envelope shapes: rising and rise/fall
- introduced an envelope loop action which loops the current envelope shape
- changed the floor of envelope timing to 50ms (0.05s)
- k3 on [loops] screen navigates:
     - levels
     - envelope shape (use e1/2/3 to choose between falling, rising, rise/fall)
     - envelope loop (use e1/2/3 to enable or disable)
     - envelope time (use e1/2/3 to dial in)
          - nb: on rise/fall, envelope time describes *each* segment, so minimum is 100ms total rise/fall journey)

## collections

addresses #3 

collections system _totally_ overhauled. no backwards compatibility with cheat codes 1 collections, which is worthwhile because there are so many changes which would require re-working old collections anyway. these revisions add tons of improvements, including:
- custom-named collections
- overwrite option w/protective timer to cancel overwrite
- delete option w/protective timer to cancel delete
- local backups of deleted collections for future restoration
- super-clear folder structure in `dust/data/cheat_codes2/[collection name]/`

## arc improvements

### encoder 4

addresses #2 

- encoder 4 acts as a meta-selector for which arc param is displayed across the three other encoders
- this allows for gridless arc param switching, making arc + midi controller as viable a setup as arc + grid
- grid shortcuts can still be used to set individual encoders to specific params

### force sensitivity

- loop window, start, and end points are sensitive to how much force is applied in a rotation
- more severe turns when long samples are loaded allows larger jumps, so you can scroll through a 32 second sample in one rotation
- minute adjustments retain previous fine-grain behavior

## general fixes

addresses #12 + #15, as well as other general trouble

FIXED:
- arc + norns encoders were not tuned correctly for variable-sized clips
- zlichmo gestures weren't tuned correctly for variable-sized clips
- arc + norns encoders respond to alt.locks
- arc + norns encoders respect envelopes
- delays respect envelopes
- delay wobble is now "fifth up" at all rates
- triangle envelope can be restarted if killed before release finishes