### PR TITLE
fixes

### DIFF
--- a/cheat_codes.lua
+++ b/cheat_codes.lua
@@ -684,6 +684,10 @@ function init()
   rec.loop = 1
   rec.clear = 0
   rec.rate_offset = 1.0
+
+  params:add_group("GRID",1)
+  params:add_option("LED_style","LED style",{"varibright","4-step","grayscale"},1)
+  params:set_action("LED_style",function() grid_dirty = true end)
   
   params:add_separator("cheat codes params")
   
@@ -3053,9 +3057,86 @@ function grid_entry(e)
   grid_dirty = true
 end
 
+led_maps =
+--                    {   VB,4S,GS  }
+{
+  -- main page
+  ["square_off"]          =   {3,4,0}
+  , ["square_selected"]   =   {15,12,15}
+  , ["square_dim"]        =   {5,4,0}
+  , ["zilchmo_off"]       =   {3,4,15} -- is this right?
+  , ["zilchmo_on"]        =   {15,12,15}
+  , ["pad_pause"]         =   {15,12,15}
+  , ["pad_play"]          =   {3,4,0}
+  , ["rec_record"]        =   {9,8,15}
+  , ["rec_overdub"]       =   {9,8,15}
+  , ["rec_play"]          =   {15,12,15}
+  , ["rec_pause"]         =   {5,4,0}
+  , ["rec_off"]           =   {3,0,0}
+  , ["arc_rec_rec"]       =   {15,12,15}
+  , ["arc_rec_play"]      =   {9,8,15}
+  , ["arc_rec_pause"]     =   {5,4,0}
+  , ["arc_rec_off"]       =   {0,0,0}
+  , ["arc_param_show"]    =   {5,4,0}
+  , ["grid_alt_on"]       =   {15,12,15}
+  , ["grid_alt_off"]      =   {3,4,0}
+  , ["clip"]              =   {8,8,15}
+  , ["mode"]              =   {6,8,15}
+  , ["loop_on"]           =   {4,8,15}
+  , ["loop_off"]          =   {4,4,0}
+  , ["arp_on"]            =   {4,4,0}
+  , ["arp_pause"]         =   {4,8,15}
+  , ["arp_play"]          =   {10,12,15}
+  , ["arp_off"]           =   {0,0,0}
+  , ["live_empty"]        =   {3,0,0}
+  , ["live_rec"]          =   {10,8,15}
+  , ["live_pause"]        =   {5,4,0}
+  , ["alt_on"]            =   {15,12,15}
+  , ["alt_off"]           =   {3,4,0}
+
+  -- seq page
+  , ["step_no_data"]      =   {2,4,0}
+  , ["step_loops"]        =   {4,8,15}
+  , ["slot_saved"]        =   {7,8,0}
+  , ["slot_empty"]        =   {2,4,0}
+  , ["slot_loaded"]       =   {15,15,15}
+  , ["step_current"]      =   {15,15,15}
+  , ["step_held"]         =   {9,8,15}
+  , ["loop_duration"]     =   {4,4,0}
+  , ["meta_duration"]     =   {4,4,15}
+  , ["meta_step_hi"]      =   {6,8,15}
+  , ["meta_step_lo"]      =   {2,4,0}
+  , ["loop_mod_hi"]       =   {12,12,15}
+  , ["loop_mod_lo"]       =   {3,4,0}
+
+  -- delay page
+  , ["bundle_empty"]      =   {2,4,0}
+  , ["bundle_saved"]      =   {7,8,0}
+  , ["bundle_loaded"]     =   {15,12,15}
+  , ["time_to_led.5"]     =   {5,4,15}
+  , ["time_to_led.25"]    =   {10,8,15}
+  , ["time_to_led.125"]   =   {15,12,15}
+  , ["time_to_led2"]      =   {3,4,15}
+  , ["time_to_led4"]      =   {6,8,15}
+  , ["time_to_led8"]      =   {12,12,15}
+  , ["time_to_led16"]     =   {15,12,15}
+  , ["reverse_on"]        =   {7,8,15}
+  , ["reverse_off"]       =   {3,4,0}
+  , ["wobble_on"]         =   {15,12,15}
+  , ["wobble_off"]        =   {0,0,0}
+  , ["level_lo"]          =   {2,4,0}
+  , ["level_hi"]          =   {7,8,15}
+  
+  -- misc
+  , ["page1_led"]         =   {0,0,15}
+  , ["page2_led"]         =   {7,8,15}
+  , ["page3_led"]         =   {15,12,15}
+}
+
 function grid_redraw()
   if g.device ~= nil then
     g:all(0)
+    local edition = params:get("LED_style")
     
     if grid_page == 0 then
       
@@ -3063,7 +3144,7 @@ function grid_redraw()
         for k = 1,4 do
           k = k+(5*j)
           for i = 8,5,-1 do
-            g:led(k,i,3)
+            g:led(k,i,led_maps["square_off"][edition])
           end
         end
       end
@@ -3071,7 +3152,7 @@ function grid_redraw()
       for j = 0,2 do
         for k = (5-j),(15-j),5 do
           for i = (4-j),1,-1 do
-            g:led(k,i,3)
+            g:led(k,i,led_maps["zilchmo_off"][edition])
           end
         end
       end
@@ -3101,13 +3182,13 @@ function grid_redraw()
           a_p = arc_param[i] - 2
         end
         if arc_pat[i][a_p].rec == 1 then
-          g:led(16,5-i,15)
+          g:led(16,5-i,led_maps["arc_rec_rec"][edition])
         elseif arc_pat[i][a_p].play == 1 then
-          g:led(16,5-i,9)
+          g:led(16,5-i,led_maps["arc_rec_play"][edition])
         elseif arc_pat[i][a_p].count > 0 then
-          g:led(16,5-i,5)
+          g:led(16,5-i,led_maps["arc_rec_pause"][edition])
         else
-          g:led(16,5-i,0)
+          g:led(16,5-i,led_maps["arc_rec_off"][edition])
         end
       end
       
@@ -3119,14 +3200,14 @@ function grid_redraw()
             g:led(j,6,arc_param[j/5] == 3 and 5 or 0)
             if arc_param[j/5] == 4 then
               for k = 8,6,-1 do
-                g:led(j,k,5)
+                g:led(j,k,led_maps["arc_param_show"][edition])
               end
             elseif arc_param[j/5] == 5 then
-              g:led(j,8,5)
-              g:led(j,7,5)
+              g:led(j,8,led_maps["arc_param_show"][edition])
+              g:led(j,7,led_maps["arc_param_show"][edition])
             elseif arc_param[j/5] == 6 then
-              g:led(j,7,5)
-              g:led(j,6,5)
+              g:led(j,7,led_maps["arc_param_show"][edition])
+              g:led(j,6,led_maps["arc_param_show"][edition])
             end
           end
         end
@@ -3134,28 +3215,28 @@ function grid_redraw()
       
       for i = 1,3 do
         if bank[i].focus_hold == false then
-          g:led(selected[i].x, selected[i].y, 15)
+          g:led(selected[i].x, selected[i].y, led_maps["square_selected"][edition])
           if i == nil then print("2339") end
           if bank[i].id == nil then print("2340", i) end
           if bank[i][bank[i].id].pause == nil then print("2341") end
           if bank[i][bank[i].id].pause == true then
-            g:led(3+(5*(i-1)),1,15)
-            g:led(3+(5*(i-1)),2,15)
+            g:led(3+(5*(i-1)),1,led_maps["pad_pause"][edition])
+            g:led(3+(5*(i-1)),2,led_maps["pad_pause"][edition])
           else
-            g:led(3+(5*(i-1)),1,3)
-            g:led(3+(5*(i-1)),2,3)
+            g:led(3+(5*(i-1)),1,led_maps["pad_play"][edition])
+            g:led(3+(5*(i-1)),2,led_maps["pad_play"][edition])
           end
         else
           local focus_x = (math.ceil(bank[i].focus_pad/4)+(5*(i-1)))
           local focus_y = 8-((bank[i].focus_pad-1)%4)
-          g:led(selected[i].x, selected[i].y, 5)
-          g:led(focus_x, focus_y, 15)
+          g:led(selected[i].x, selected[i].y, led_maps["square_dim"][edition])
+          g:led(focus_x, focus_y, led_maps["square_selected"][edition])
           if bank[i][bank[i].focus_pad].pause == true then
-            g:led(3+(5*(i-1)),1,15)
-            g:led(3+(5*(i-1)),2,15)
+            g:led(3+(5*(i-1)),1,led_maps["square_selected"][edition])
+            g:led(3+(5*(i-1)),2,led_maps["square_selected"][edition])
           else
-            g:led(3+(5*(i-1)),1,3)
-            g:led(3+(5*(i-1)),2,3)
+            g:led(3+(5*(i-1)),1,led_maps["square_off"][edition])
+            g:led(3+(5*(i-1)),2,led_maps["square_off"][edition])
           end
         end
       end
@@ -3170,10 +3251,10 @@ function grid_redraw()
       end
       
       for i,e in pairs(lit) do
-        g:led(e.x, e.y,15)
+        g:led(e.x, e.y,led_maps["square_selected"][edition])
       end
       
-      g:led(16,8,(grid.alt and 12 or 0)+3)
+      g:led(16,8,(grid.alt and led_maps["alt_on"][edition] or led_maps["alt_off"][edition]))
       
       for i = 1,3 do
         if bank[i].focus_hold == false then

--- a/cheat_codes.lua
+++ b/cheat_codes.lua
@@ -2209,6 +2209,9 @@ function cheat(b,i)
   if osc_communication == true then
     osc_redraw(b)
   end
+  if all_loaded and params:get("midi_echo_enabled") == 2 then
+    mc.redraw(pad)
+  end
 end
 
 function envelope(i)

--- a/lib/delay.lua
+++ b/lib/delay.lua
@@ -41,6 +41,7 @@ function delays.init(target)
     delay[i].saver_active = false
     delay[i].selected_bundle = 0
     delay[i].wobble_hold = false
+    delay[i].reverse = false
   end
 
   delay_bundle = { {},{} }
@@ -191,6 +192,10 @@ function delays.quick_action(target,param)
     local duration = delay[target].mode == "clocked" and delay[target].end_point-delay[target].start_point or delay[target].free_end_point-delay[target].start_point
     softcut.buffer_clear_region_channel(1, 41 + (30*(target-1)), duration+ params:get(target == 1 and "delay L: fade time" or "delay R: fade time"))
     softcut.level(target+4,params:get(target == 1 and "delay L: global level" or "delay R: global level"))
+  elseif param == "reverse" then
+    delay[target].reverse = not delay[target].reverse
+    local rate = {"delay L: rate", "delay R: rate"}
+    softcut.rate(target+4,params:get(rate[target])*(delay[target].reverse and -1 or 1))
   end
 end
 

--- a/lib/encoder_actions.lua
+++ b/lib/encoder_actions.lua
@@ -42,15 +42,19 @@ function encoder_actions.init(n,d)
         end
       end
     elseif menu == 6 then
-      if page.delay_section == 1 then
-        page.delay_focus = util.clamp(page.delay_focus+d,1,2)
-      elseif page.delay_section == 2 then
-        page.delay[page.delay_focus].menu = util.clamp(page.delay[page.delay_focus].menu+d,1,3)
-      elseif page.delay_section == 3 then
-        local max_lines = {3,3,4}
-        local target = page.delay[page.delay_focus].menu_sel[page.delay[page.delay_focus].menu]
-        page.delay[page.delay_focus].menu_sel[page.delay[page.delay_focus].menu] = util.clamp(target+d,1,max_lines[page.delay[page.delay_focus].menu])
-      end
+
+      page.delay_focus = util.clamp(page.delay_focus+d,1,2)
+
+      -- if page.delay_section == 1 then
+      --   page.delay_focus = util.clamp(page.delay_focus+d,1,2)
+      -- elseif page.delay_section == 2 then
+      --   page.delay[page.delay_focus].menu = util.clamp(page.delay[page.delay_focus].menu+d,1,3)
+      -- elseif page.delay_section == 3 then
+      --   local max_lines = {3,3,4}
+      --   local target = page.delay[page.delay_focus].menu_sel[page.delay[page.delay_focus].menu]
+      --   page.delay[page.delay_focus].menu_sel[page.delay[page.delay_focus].menu] = util.clamp(target+d,1,max_lines[page.delay[page.delay_focus].menu])
+      -- end
+
     elseif menu == 7 then
       page.time_sel = util.clamp(page.time_sel+d,1,6)
     elseif menu == 8 then
@@ -114,73 +118,15 @@ function encoder_actions.init(n,d)
         end
       end
     elseif menu == 6 then
-      -- local line = page.delay_sel
-      -- if line == 0 then
-      --   local divisor = (delay[1].mode == "free" and key1_hold) and 100 or 1
-      --   params:delta(delay[1].mode == "clocked" and "delay L: div/mult" or "delay L: free length",d/divisor)
-      -- elseif line == 1 then
-      --   params:delta("delay L: feedback",d)
-      -- elseif line ==  2 then
-      --   params:delta("delay L: filter cut",d/10)
-      -- elseif line == 3 then
-      --   params:delta("delay L: filter q",d/2)
-      -- elseif line == 4 then
-      --   params:delta("delay L: global level",d)
-      -- end
-      local line = page.delay[page.delay_focus].menu_sel[page.delay[page.delay_focus].menu]
-      local delay_name = page.delay_focus == 1 and "L" or "R"
-      local focused_menu = page.delay[page.delay_focus].menu
-      if page.delay_section == 3 then
-        if focused_menu == 1 then
-          if line == 1 then
-            params:delta("delay "..delay_name..": mode",d)
-          elseif line == 2 then
-            local divisor = (delay[page.delay_focus].mode == "free" and key1_hold) and 10 or 0.2
-            params:delta("delay "..delay_name..": fade time",d/divisor)
-          elseif line == 3 then
-            params:delta("delay "..delay_name..": feedback",d)
-          end
-        elseif focused_menu == 2 then
-          if line == 1 then
-            params:delta("delay "..delay_name..": filter cut",d/10)
-          elseif line == 2 then
-            params:delta("delay "..delay_name..": filter lp",d)
-          elseif line == 3 then
-            params:delta("delay "..delay_name..": filter bp",d)
-          end
 
-        -- elseif focused_menu == 3 then
-        --   if line == 1 then
-        --     params:delta("delay "..delay_name..": (a) send",d*2)
-        --   elseif line == 2 then
-        --     params:delta("delay "..delay_name..": (b) send",d*2)
-        --   elseif line == 3 then
-        --     params:delta("delay "..delay_name..": (c) send",d*2)
-        --   end
-        elseif focused_menu == 3 then
-          if line < 4 then
-            if page.delay_focus == 1 then
-              if key1_hold then
-                for i = 1,16 do
-                  bank[line][i].left_delay_level = util.clamp(bank[line][i].left_delay_level + d/10,0,1)
-                end
-              else
-                bank[line][bank[line].id].left_delay_level = util.clamp(bank[line][bank[line].id].left_delay_level + d/10,0,1)
-              end
-            elseif page.delay_focus == 2 then
-              if key1_hold then
-                for i = 1,16 do
-                  bank[line][i].right_delay_level = util.clamp(bank[line][i].right_delay_level + d/10,0,1)
-                end
-              else
-                bank[line][bank[line].id].right_delay_level = util.clamp(bank[line][bank[line].id].right_delay_level + d/10,0,1)
-              end
-            end
-          elseif line == 4 then
-            params:delta("delay "..delay_name..": global level",d)
-          end
-        end
+      if page.delay_section == 1 then
+        page.delay[page.delay_focus].menu = util.clamp(page.delay[page.delay_focus].menu+d,1,3)
+      elseif page.delay_section == 2 then
+        local max_items = {5,6,7}
+        local target = page.delay[page.delay_focus].menu_sel[page.delay[page.delay_focus].menu]
+        page.delay[page.delay_focus].menu_sel[page.delay[page.delay_focus].menu] = util.clamp(target+d,1,max_items[page.delay[page.delay_focus].menu])
       end
+      
     elseif menu == 7 then
       local time_page = page.time_page_sel
       local page_line = page.time_sel
@@ -325,25 +271,15 @@ function encoder_actions.init(n,d)
         end
       end
     elseif menu == 6 then
-      -- local line = page.delay_sel
-      -- if line == 0 then
-      --   params:delta(delay[2].mode == "clocked" and "delay R: div/mult" or "delay R: free length",d)
-      -- elseif line == 1 then
-      --   params:delta("delay R: feedback",d)
-      -- elseif line ==  2 then
-      --   params:delta("delay R: filter cut",d/10)
-      -- elseif line == 3 then
-      --   params:delta("delay R: filter q",d/2)
-      -- elseif line == 4 then
-      --   params:delta("delay R: global level",d)
-      -- end
-      local line = page.delay[page.delay_focus].menu_sel[page.delay[page.delay_focus].menu]
+
+      local item = page.delay[page.delay_focus].menu_sel[page.delay[page.delay_focus].menu]
       local delay_name = page.delay_focus == 1 and "L" or "R"
       local focused_menu = page.delay[page.delay_focus].menu
-      if page.delay_section == 3 then
+      if page.delay_section == 2 then
         if focused_menu == 1 then
-          if line == 1 then
-            -- local divisor = (delay[page.delay_focus].mode == "free" and key1_hold) and (1/(33+(1/3)))*100 or 1/(33+(1/3))
+          if item == 1 then
+            params:delta("delay "..delay_name..": mode",d)
+          elseif item == 2 then
             local divisor;
             if delay[page.delay_focus].mode == "free" and key1_hold then
               divisor = 3
@@ -353,7 +289,98 @@ function encoder_actions.init(n,d)
               divisor = 1
             end
             params:delta(delay[page.delay_focus].mode == "clocked" and "delay "..delay_name..": div/mult" or "delay "..delay_name..": free length",d/divisor)
-          elseif line == 2 then
+          elseif item == 3 then
+            local divisor = (delay[page.delay_focus].mode == "free" and key1_hold) and 10 or 0.2
+            params:delta("delay "..delay_name..": fade time",d/divisor)
+          elseif item == 4 then
+            if key1_hold then
+              params:delta("delay "..delay_name..": rate",d)
+            else
+              if params:get("delay "..delay_name..": rate") < 1.0 then
+                if d > 0 then
+                  if params:get("delay "..delay_name..": rate") * 2 < 1.0 then
+                    params:set("delay "..delay_name..": rate",params:get("delay "..delay_name..": rate") * 2)
+                  else
+                    params:set("delay "..delay_name..": rate",1)
+                  end
+                else
+                  if params:get("delay "..delay_name..": rate") / 2 >= 0.25 then
+                    params:set("delay "..delay_name..": rate",params:get("delay "..delay_name..": rate") / 2)
+                  else
+                    params:set("delay "..delay_name..": rate",1)
+                  end
+                end
+              else
+                params:delta("delay "..delay_name..": rate",d*100)
+                if params:get("delay "..delay_name..": rate") < 1.0 then
+                  params:set("delay "..delay_name..": rate",1)
+                end
+              end
+            end
+          elseif item == 5 then
+            params:delta("delay "..delay_name..": feedback",d)
+          end
+        elseif focused_menu == 2 then
+          if item == 1 then
+            params:delta("delay "..delay_name..": filter cut",d/10)
+          elseif item == 2 then
+            params:delta("delay "..delay_name..": filter q",d/10)
+          elseif item == 3 then
+            params:delta("delay "..delay_name..": filter lp",d)
+          elseif item == 4 then
+            params:delta("delay "..delay_name..": filter hp",d)
+          elseif item == 5 then
+            params:delta("delay "..delay_name..": filter bp",d)
+          elseif item == 6 then
+            params:delta("delay "..delay_name..": filter dry",d)
+          end
+        elseif focused_menu == 3 then
+          if item < 7 then
+            if item == 1 or item == 3 or item == 5 then
+              local target = bank[util.round(item/2)]
+              local prm = {"left_delay_level","right_delay_level"}
+              if key1_hold then
+                for i = 1,16 do
+                  target[i][prm[page.delay_focus]] = util.clamp(target[i][prm[page.delay_focus]] + d/10,0,1)
+                end
+              else
+                target[target.id][prm[page.delay_focus]] = util.clamp(target[target.id][prm[page.delay_focus]] + d/10,0,1)
+              end
+            else
+              local target = bank[item/2]
+              local prm = {"left_delay_thru","right_delay_thru"}
+              local current_thru = target[target.id][prm[page.delay_focus]] == true and 1 or 0
+              current_thru = util.clamp(current_thru + d,0,1)
+              if key1_hold then
+                for i = 1,16 do
+                  target[i][prm[page.delay_focus]] = current_thru == 1 and true or false
+                end
+              else
+                target[target.id][prm[page.delay_focus]] = current_thru == 1 and true or false
+              end
+            end
+          elseif item == 7 then
+            params:delta("delay "..delay_name..": global level",d)
+          end
+        end
+      end
+
+      local item = page.delay[page.delay_focus].menu_sel[page.delay[page.delay_focus].menu]
+      local delay_name = page.delay_focus == 1 and "L" or "R"
+      local focused_menu = page.delay[page.delay_focus].menu
+      if page.delay_section == 3 then
+        if focused_menu == 1 then
+          if item == 1 then
+            local divisor;
+            if delay[page.delay_focus].mode == "free" and key1_hold then
+              divisor = 3
+            elseif delay[page.delay_focus].mode == "free" and not key1_hold then
+              divisor = 1/(100/3)
+            else
+              divisor = 1
+            end
+            params:delta(delay[page.delay_focus].mode == "clocked" and "delay "..delay_name..": div/mult" or "delay "..delay_name..": free length",d/divisor)
+          elseif item == 2 then
             if key1_hold then
               params:delta("delay "..delay_name..": rate",d)
             else
@@ -364,37 +391,38 @@ function encoder_actions.init(n,d)
             end
           end
         elseif focused_menu == 2 then
-          if line == 1 then
+          if item == 1 then
             params:delta("delay "..delay_name..": filter q",d/10)
-          elseif line == 2 then
+          elseif item == 2 then
             params:delta("delay "..delay_name..": filter hp",d)
-          elseif line == 3 then
+          elseif item == 3 then
             params:delta("delay "..delay_name..": filter dry",d)
           end
         elseif focused_menu == 3 then
           if page.delay_focus == 1 then
-            local current_thru = bank[line][bank[line].id].left_delay_thru == true and 1 or 0
+            local current_thru = bank[item][bank[item].id].left_delay_thru == true and 1 or 0
             current_thru = util.clamp(current_thru + d,0,1)
             if key1_hold then
               for i = 1,16 do
-                bank[line][i].left_delay_thru = current_thru == 1 and true or false
+                bank[item][i].left_delay_thru = current_thru == 1 and true or false
               end
             else
-              bank[line][bank[line].id].left_delay_thru = current_thru == 1 and true or false
+              bank[item][bank[item].id].left_delay_thru = current_thru == 1 and true or false
             end
           elseif page.delay_focus == 2 then
-            local current_thru = bank[line][bank[line].id].right_delay_thru == true and 1 or 0
+            local current_thru = bank[item][bank[item].id].right_delay_thru == true and 1 or 0
             current_thru = util.clamp(current_thru + d,0,1)
             if key1_hold then
               for i = 1,16 do
-                bank[line][i].right_delay_thru = current_thru == 1 and true or false
+                bank[item][i].right_delay_thru = current_thru == 1 and true or false
               end
             else
-              bank[line][bank[line].id].right_delay_thru = current_thru == 1 and true or false
+              bank[item][bank[item].id].right_delay_thru = current_thru == 1 and true or false
             end
           end
         end
       end
+
     elseif menu == 7 then
       local time_page = page.time_page_sel
       local page_line = page.time_sel
@@ -616,16 +644,10 @@ function encoder_actions.init(n,d)
     end
     if page.levels_sel == 0 then
       if key1_hold or grid.alt or bank[n].alt_lock then
-        -- for i = 1,16 do
-        --   bank[n][i].level = util.clamp(bank[n][i].level+d/10,0,2)
-        -- end
         bank[n].global_level = util.clamp(bank[n].global_level+d/10,0,2)
       else
         bank[n][focused_pad].level = util.clamp(bank[n][focused_pad].level+d/10,0,2)
       end
-      -- TODO figure out of this is necessary:
-      -- it wouldn't let you adjust the volume on an enveloped
-      -- if bank[n][bank[n].id].enveloped == false then
       if bank[n][bank[n].id].envelope_mode == 2 or bank[n][bank[n].id].enveloped == false then
         if bank[n].focus_hold == false then
           softcut.level_slew_time(n+1,1.0)
@@ -645,33 +667,12 @@ function encoder_actions.init(n,d)
 
           if bank[n][j].envelope_mode == 0 then
             bank[n][j].enveloped = false
-            -- TODO: figure out if this is necessary
-            -- if pre_enveloped ~= bank[n][j].enveloped then
-            --   cheat(n, bank[n].id)
-            -- end
           else
             bank[n][j].enveloped = true
             if pre_enveloped ~= bank[n][j].enveloped then
               cheat(n, bank[n].id)
             end
           end
-
-          -- if bank[n][j].enveloped then
-          --   if d < 0 then
-          --     bank[n][j].enveloped = false
-          --     if pre_enveloped ~= bank[n][j].enveloped then
-          --       cheat(n, bank[n].id)
-          --     end
-          --   end
-          -- else
-          --   if d > 0 then
-          --     bank[n][j].enveloped = true
-          --     if pre_enveloped ~= bank[n][j].enveloped then
-          --       cheat(n, bank[n].id)
-          --     end
-          --   end
-          -- end
-          
         end
 
       else
@@ -682,11 +683,6 @@ function encoder_actions.init(n,d)
         
         if bank[n][focused_pad].envelope_mode == 0 then
           bank[n][focused_pad].enveloped = false
-          -- if pre_enveloped ~= bank[n][bank[n].id].enveloped then
-          --   if bank[n].focus_hold == false then
-          --     cheat(n, bank[n].id)
-          --   end
-          -- end
         else
           bank[n][focused_pad].enveloped = true
           if pre_enveloped ~= bank[n][focused_pad].enveloped then
@@ -930,12 +926,13 @@ function ea.change_pad_clip(target,delta)
   end
   
   if focused_pad == 16 then
-
     for i = 1,15 do
-      change_mode(bank[target][i],bank[target][16].mode)
+      if bank[target][16].mode ~= bank[target][i].mode then
+        bank[target][i].mode = bank[target][16].mode
+        change_mode(bank[target][i],bank[target][i].mode == 2 and 1 or 2)
+      end
       jump_clip(target,i,bank[target][16].clip)
     end
-  
   end
   
   grid_dirty = true

--- a/lib/grid_actions.lua
+++ b/lib/grid_actions.lua
@@ -726,9 +726,11 @@ function grid_actions.init(x,y,z)
   
   elseif grid_page == 2 then
     if y == 3 or y == 6 then
-      if x <= 3 and z == 1 then
+      if x <= 2 and z == 1 then
         local changes = {"double", "halve", "sync"}
         del.change_duration(y == 6 and 1 or 2, y == 6 and 2 or 1, changes[x])
+      elseif x == 3 and z == 1 then
+        del.quick_action(y == 6 and 1 or 2, "reverse")
       elseif x >= 4 and x <= 8 then
         if z == 1 then
           del.set_value(math.abs(5-y), x-3, "level")

--- a/lib/leds.lua
+++ b/lib/leds.lua
@@ -1,0 +1,71 @@
+led_mappings =
+--                    {   VB,4S,GS  }
+{
+  -- main page
+  "square_off"        =   {3,4,0}
+  , "square_selected" =   {15,12,15}
+  , "square_dim"      =   {5,4,0}
+  , "zilchmo_off"     =   {3,4,15} -- is this right?
+  , "zilchmo_on"      =   {15,12,15}
+  , "rec_record"      =   {9,8,15}
+  , "rec_overdub"     =   {9,8,15}
+  , "rec_play"        =   {15,12,15}
+  , "rec_pause"       =   {5,4,0}
+  , "rec_off"         =   {3,0,0}
+  , "arc_rec_rec"     =   {15,12,15}
+  , "arc_rec_play"    =   {9,8,15}
+  , "arc_rec_pause"   =   {5,4,0}
+  , "arc_rec_off"     =   {0,0,0}
+  , "arc_param_show"  =   {5,4,0}
+  , "grid_alt_on"     =   {15,12,15}
+  , "grid_alt_off"    =   {3,4,0}
+  , "clip"            =   {8,8,15}
+  , "mode"            =   {6,8,15}
+  , "loop_on"         =   {4,8,15}
+  , "loop_off"        =   {4,4,0}
+  , "arp_on"          =   {4,4,0}
+  , "arp_pause"       =   {4,8,15}
+  , "arp_play"        =   {10,12,15}
+  , "arp_off"         =   {0,0,0}
+  , "live_empty"      =   {3,0,0}
+  , "live_rec"        =   {10,8,15}
+  , "live_pause"      =   {5,4,0}
+
+  -- seq page
+  , "step_no_data"    =   {2,4,0}
+  , "step_loops"      =   {4,8,15}
+  , "slot_saved"      =   {7,8,0}
+  , "slot_empty"      =   {2,4,0}
+  , "slot_loaded"     =   {15,15,15}
+  , "step_current"    =   {15,15,15}
+  , "step_held"       =   {9,8,15}
+  , "loop_duration"   =   {4,4,0}
+  , "meta_duration"   =   {4,4,15}
+  , "meta_step_hi"    =   {6,8,15}
+  , "meta_step_lo"    =   {2,4,0}
+  , "loop_mod_hi"     =   {12,12,15}
+  , "loop_mod_lo"     =   {3,4,0}
+
+  -- delay page
+  , "bundle_empty"    =   {2,4,0}
+  , "bundle_saved"    =   {7,8,0}
+  , "bundle_loaded"   =   {15,12,15}
+  , "time_to_led.5"   =   {5,4,15}
+  , "time_to_led.25"  =   {10,8,15}
+  , "time_to_led.125" =   {15,12,15}
+  , "time_to_led2"    =   {3,4,15}
+  , "time_to_led4"    =   {6,8,15}
+  , "time_to_led8"    =   {12,12,15}
+  , "time_to_led16"   =   {15,12,15}
+  , "reverse_on"      =   {7,8,15}
+  , "reverse_off"     =   {3,4,0}
+  , "wobble_on"       =   {15,12,15}
+  , "wobble_off"      =   {0,0,0}
+  , "level_lo"        =   {2,4,0}
+  , "level_hi"        =   {7,8,15}
+  
+  -- misc
+  , "page1_led"       =   {0,0,15}
+  , "page2_led"       =   {7,8,15}
+  , "page3_led"       =   {15,12,15}
+}

--- a/lib/main_menu.lua
+++ b/lib/main_menu.lua
@@ -903,7 +903,15 @@ function main_menu.init()
     screen.font_size(10)
     if collection_loaded then
       screen.text_center("loading collection")
-      screen.font_size(30)
+      if #selected_coll < 8 then
+        screen.font_size(30)
+      elseif #selected_coll < 11 then
+        screen.font_size(20)
+      elseif #selected_coll < 14 then
+        screen.font_size(15)
+      else
+        screen.font_size(10)
+      end
       screen.move(62,43)
       screen.text_center(selected_coll)
       screen.font_size(15)

--- a/lib/main_menu.lua
+++ b/lib/main_menu.lua
@@ -46,32 +46,12 @@ function main_menu.init()
     screen.level(3)
     screen.text("loops")
 
-    -- local bank_rate = {}
-    -- for i = 1,3 do
-    --   bank_rate[i] = string.format("%.4g",bank[i][bank[i].id].rate)
-    -- end
-    -- screen.move(120,10)
-    -- screen.text_right(bank_rate[1].."x | "..bank_rate[2].."x | "..bank_rate[3].."x")
-
     screen.move(120,10)
     if page.loops_sel ~= 4 then
       local pad = bank[page.loops_sel][bank[page.loops_sel].id]
       local s_p = pad.mode == 1 and live[pad.clip].min or clip[pad.clip].min
       local e_p = pad.mode == 1 and live[pad.clip].max or clip[pad.clip].max
       local dur = e_p-s_p
-
-      -- if pad.mode == 1 then
-      --   --slice within bounds
-      --   dur = rec.end_point-rec.start_point
-      --   s_p = (rec.start_point+((duration/16) * (pad.pad_id-1)))+((pad.clip-1)*8)
-      --   e_p = (rec.start_point+((duration/16) * (pad.pad_id)))+((pad.clip-1)*8)
-      -- else
-      --   duration = pad.mode == 1 and 8 or clip[pad.clip].sample_length
-      --   pad.start_point = ((duration/16)*(pad.pad_id-1)) + clip[pad.clip].min
-      --   pad.end_point = pad.start_point + (duration/16)
-      --   print(duration, pad.start_point, pad.end_point)
-      -- end
-
       local off = pad.mode == 1 and (((pad.clip-1)*8)+1) or clip[pad.clip].min
       local display_end = pad.mode == 1 and (pad.end_point == 8.99 and 9 or pad.end_point) or pad.end_point
       screen.text_right("s: "..string.format("%.4g",(pad.start_point)-off).."s | e: "..string.format("%.4g",(display_end)-off).."s")
@@ -91,9 +71,6 @@ function main_menu.init()
       screen.move(0,8+(i*14))
       screen.level(page.loops_sel == i and 15 or 3)
 
-      -- local loops_to_screen_options = {"a", "b", "c"}
-      -- screen.text(loops_to_screen_options[i]..""..which_pad)
-
       if not grid.alt then
         local loops_to_screen_options = {"a", "b", "c"}
         screen.text(loops_to_screen_options[i]..""..which_pad)
@@ -102,18 +79,25 @@ function main_menu.init()
         screen.text(loops_to_screen_options[i])
       end
 
+      if key1_hold then
+        screen.move(122,8+(page.loops_sel*14))
+        screen.text("*")
+      else
+        screen.move(122,8+(i*14))
+        screen.text(bank[i][bank[i].focus_hold == false and bank[i].id or bank[i].focus_pad].loop and "L" or "")
+      end
 
       if page.loops_view[i] == 1 then
         screen.move(15,8+(i*14))
         screen.line(120,8+(i*14))
         screen.close()
         screen.stroke()
+        screen.level(page.loops_sel == i and 15 or 3)
         if bank[i].focus_hold == false then
           which_pad = bank[i].id
         else
           which_pad = bank[i].focus_pad
         end
-        screen.level(page.loops_sel == i and 15 or 3)
         local duration = bank[i][which_pad].mode == 1 and 8 or clip[bank[i][which_pad].clip].sample_length
         local s_p = bank[i][which_pad].mode == 1 and live[bank[i][which_pad].clip].min or clip[bank[i][which_pad].clip].min
         local e_p = bank[i][which_pad].mode == 1 and live[bank[i][which_pad].clip].max or clip[bank[i][which_pad].clip].max
@@ -384,6 +368,7 @@ function main_menu.init()
     screen.level(3)
     screen.move(0,64)
     screen.text("...")
+
   elseif menu == 6 then
     screen.move(0,10)
     screen.level(3)
@@ -391,40 +376,43 @@ function main_menu.init()
     local focused_menu = page.delay[page.delay_focus].menu
     if key1_hold then
       screen.move(128,10)
-      if page.delay_section == 3 and focused_menu == 1 then
-        if page.delay[page.delay_focus].menu_sel[focused_menu] == 1 or page.delay[page.delay_focus].menu_sel[focused_menu] == 2 then
-          screen.text_right(page.delay[page.delay_focus].menu_sel[focused_menu] == 1 and "enc3: fine-tune" or "enc2+3: fine-tune")
+      if page.delay_section == 2 and focused_menu == 1 then
+        local focused_prm = page.delay[page.delay_focus].menu_sel[focused_menu]
+        if (delay[page.delay_focus].mode == "free" and focused_prm == 2) or (delay[page.delay_focus].mode == "free" and focused_prm == 3) or focused_prm == 4 then
+          screen.text_right("fine-tune enabled")
+        elseif focused_prm == 5 then
+          screen.text_right("quick-jump!!")
         end
-      elseif page.delay_section == 3 and focused_menu == 3 then
-        if page.delay[page.delay_focus].menu_sel[focused_menu] < 4 then
+      elseif page.delay_section == 2 and focused_menu == 3 then
+        if page.delay[page.delay_focus].menu_sel[focused_menu] < 7 then
           screen.text_right("map changes to bank")
         end
       end
     end
-    screen.level(page.delay_section == 1 and 15 or 3)
+    screen.level(15)
     screen.font_size(40)
     screen.move(0,50)
     screen.text(page.delay_focus == 1 and "L" or "R")
     screen.font_size(8)
-    -- local focused_menu = page.delay[page.delay_focus].menu
     local options = {"ctl","flt","mix"}
     for i = 1,3 do
-      screen.level((page.delay_section == 2 and focused_menu == i) and 15 or 3)
+      screen.level((page.delay_section == 1 and focused_menu == i) and 15 or 3)
       screen.move(30+(40*(i-1)),20)
       screen.text(options[i])
     end
-    screen.level((page.delay_section == 2 and focused_menu == focused_menu) and 15 or 3)
+    screen.level((page.delay_section == 1 and focused_menu == focused_menu) and 15 or 3)
     screen.move(30+(40*(focused_menu-1)),23)
     screen.line((focused_menu == 3 and 41 or 40)+(40*(focused_menu-1)),23)
     screen.stroke()
     local delay_name = page.delay_focus == 1 and "L" or "R"
-    screen.level((page.delay_section == 3 and focused_menu == focused_menu) and 15 or 3)
+    screen.level((page.delay_section == 2 and focused_menu == focused_menu) and 15 or 3)
     local selected = page.delay[page.delay_focus].menu_sel[focused_menu]
     if focused_menu == 1 then
-      screen.level((page.delay_section == 3 and selected == 1) and 15 or 3)
+      screen.level((page.delay_section == 2 and selected == 1) and 15 or 3)
       screen.move(30,30)
       screen.text(params:string("delay "..delay_name..": mode"))
       screen.move(75,30)
+      screen.level((page.delay_section == 2 and selected == 2) and 15 or 3)
       if delay[page.delay_focus].mode == "clocked" then
         if delay[page.delay_focus].modifier ~= 1 then
           screen.text(params:string("delay "..delay_name..": div/mult").."*"..string.format("%.4g",delay[page.delay_focus].modifier))
@@ -434,59 +422,63 @@ function main_menu.init()
       else
         screen.text(string.format("%.4g",params:get("delay "..delay_name..": free length")).." sec")
       end
-      screen.level((page.delay_section == 3 and selected == 2) and 15 or 3)
+      screen.level((page.delay_section == 2 and selected == 3) and 15 or 3)
       screen.move(30,40)
       screen.text("fade: "..string.format("%.4g",params:get("delay "..delay_name..": fade time")))
+      screen.level((page.delay_section == 2 and selected == 4) and 15 or 3)
       screen.move(85,40)
       screen.text("rate: "..string.format("%.4g",params:string("delay "..delay_name..": rate")))
-      screen.level((page.delay_section == 3 and selected == 3) and 15 or 3)
+      screen.level((page.delay_section == 2 and selected == 5) and 15 or 3)
       screen.move(30,50)
-      screen.text("feedback: "..string.format("%.4g",params:get("delay "..delay_name..": feedback")).."%")
+      if delay[page.delay_focus].feedback_mute then
+        if params:get(page.delay_focus == 1 and "delay L: feedback" or "delay R: feedback") == 0 then
+          screen.text("feedback: 100%")
+        else
+          screen.text("feedback: 0%")
+        end
+      else
+        screen.text("feedback: "..string.format("%.4g",params:get("delay "..delay_name..": feedback")).."%")
+      end
     elseif focused_menu == 2 then
-      screen.level((page.delay_section == 3 and selected == 1) and 15 or 3)
+      screen.level((page.delay_section == 2 and selected == 1) and 15 or 3)
       screen.move(30,30)
       screen.text(params:string("delay "..delay_name..": filter cut"))
+      screen.level((page.delay_section == 2 and selected == 2) and 15 or 3)
       screen.move(85,30)
       screen.text("q: "..params:string("delay "..delay_name..": filter q"))
-      screen.level((page.delay_section == 3 and selected == 2) and 15 or 3)
+      screen.level((page.delay_section == 2 and selected == 3) and 15 or 3)
       screen.move(30,40)
       screen.text("LP: "..params:string("delay "..delay_name..": filter lp"))
+      screen.level((page.delay_section == 2 and selected == 4) and 15 or 3)
       screen.move(85,40)
       screen.text("HP: "..params:string("delay "..delay_name..": filter hp"))
-      screen.level((page.delay_section == 3 and selected == 3) and 15 or 3)
+      screen.level((page.delay_section == 2 and selected == 5) and 15 or 3)
       screen.move(30,50)
       screen.text("BP: "..params:string("delay "..delay_name..": filter bp"))
+      screen.level((page.delay_section == 2 and selected == 6) and 15 or 3)
       screen.move(85,50)
       screen.text("dry: "..params:string("delay "..delay_name..": filter dry"))
     elseif focused_menu == 3 then
-      screen.level((page.delay_section == 3 and selected == 1) and 15 or 3)
-      screen.move(30,30)
-      screen.text("a"..bank[1].id)
-      screen.move(50,30)
-      screen.text("in: "..string.format("%.1f",(page.delay_focus == 1 and bank[1][bank[1].id].left_delay_level or bank[1][bank[1].id].right_delay_level)))
-      screen.move(80,30)
-      screen.text("thru: "..(page.delay_focus == 1 and tostring(bank[1][bank[1].id].left_delay_thru) or tostring(bank[1][bank[1].id].right_delay_thru)))
-      screen.level((page.delay_section == 3 and selected == 2) and 15 or 3)
-      screen.move(30,40)
-      screen.text("b"..bank[2].id)
-      screen.move(50,40)
-      screen.text("in: "..string.format("%.1f",(page.delay_focus == 1 and bank[2][bank[2].id].left_delay_level or bank[2][bank[2].id].right_delay_level)))
-      screen.move(80,40)
-      screen.text("thru: "..(page.delay_focus == 1 and tostring(bank[2][bank[2].id].left_delay_thru) or tostring(bank[2][bank[2].id].right_delay_thru)))
-      screen.level((page.delay_section == 3 and selected == 3) and 15 or 3)
-      screen.move(30,50)
-      screen.text("c"..bank[3].id)
-      screen.move(50,50)
-      screen.text("in: "..string.format("%.1f",(page.delay_focus == 1 and bank[3][bank[3].id].left_delay_level or bank[3][bank[3].id].right_delay_level)))
-      screen.move(80,50)
-      screen.text("thru: "..(page.delay_focus == 1 and tostring(bank[3][bank[3].id].left_delay_thru) or tostring(bank[3][bank[3].id].right_delay_thru)))
-      screen.level((page.delay_section == 3 and selected == 4) and 15 or 3)
+      local bank_names = {"a","b","c"}
+      for i = 1,3 do
+        screen.level(3)
+        screen.move(30,20+(i*10))
+        screen.text(bank_names[i]..""..bank[i].id)
+        screen.level((page.delay_section == 2 and selected == (i == 1 and 1 or (i == 2 and 3 or 5))) and 15 or 3)
+        screen.move(50,20+(i*10))
+        screen.text("in: "..string.format("%.1f",(page.delay_focus == 1 and bank[i][bank[i].id].left_delay_level or bank[i][bank[i].id].right_delay_level)))
+        screen.level((page.delay_section == 2 and selected == (i == 1 and 2 or (i == 2 and 4 or 6))) and 15 or 3)
+        screen.move(80,20+(i*10))
+        screen.text("thru: "..(page.delay_focus == 1 and tostring(bank[i][bank[i].id].left_delay_thru) or tostring(bank[i][bank[i].id].right_delay_thru)))
+      end
+      screen.level((page.delay_section == 2 and selected == 7) and 15 or 3)
       screen.move(30,60)
       screen.text("main output level: "..string.format("%.2f", params:get("delay "..delay_name..": global level")))
     end
     screen.level(3)
     screen.move(0,64)
     screen.text("...")
+  
   elseif menu == 7 then
     screen.move(0,10)
     screen.level(3)

--- a/lib/midicheat.lua
+++ b/lib/midicheat.lua
@@ -1,0 +1,155 @@
+local midicheat = {}
+
+local mc = midicheat
+
+function mc.init()
+  for i = 1,3 do
+    mc.redraw(bank[i][bank[i].id])
+  end
+end
+
+function mc.move_start(target,val) -- expects (bank[x][y],0-127)
+  local lo = target.mode == 1 and live[target.clip].min or clip[target.clip].min
+  local hi = target.end_point-0.1
+  local max = target.mode == 1 and live[target.clip].max or clip[target.clip].max
+  target.start_point = util.round(util.clamp(util.linlin(0,127,lo,max,val),lo,hi),0.1)
+  softcut.loop_start(target.bank_id+1,target.start_point)
+  params:set("start point "..target.bank_id,val,"true")
+  redraw()
+end
+
+function mc.move_end(target,val) -- expects (bank[x][y],0-127)
+  local lo = target.start_point+0.1
+  local hi = target.mode == 1 and live[target.clip].max or clip[target.clip].max
+  local min = target.mode == 1 and live[target.clip].min or clip[target.clip].min
+  target.end_point = util.round(util.clamp(util.linlin(0,127,min,hi,val),lo,hi),0.1)
+  softcut.loop_end(target.bank_id+1,target.end_point)
+  params:set("end point "..target.bank_id,val,"true")
+  redraw()
+end
+
+function mc.adjust_filter(target,val) -- expects (x,0-127)
+  for j = 1,16 do
+    local which_bank = bank[target][j]
+    if slew_counter[target] ~= nil then
+      slew_counter[target].prev_tilt = which_bank.tilt
+    end
+    which_bank.tilt = util.linlin(0,127,-1,1,val)
+  end
+  local pad = bank[target][bank[target].id]
+  slew_filter(target,slew_counter[target].prev_tilt,pad.tilt,pad.q,pad.q,15)
+  redraw()
+end
+
+function mc.adjust_pad_level(target,val) -- expects (bank[x][y],0-127)
+  target.level = util.linlin(0,127,0,2,val)
+  if target.envelope_mode == 2 or not target.enveloped then
+    softcut.level_slew_time(target.bank_id +1,1.0)
+    softcut.level(target.bank_id +1,target.level*bank[target.bank_id].global_level)
+    softcut.level_cut_cut(target.bank_id +1,5,(target.left_delay_level*target.level)*bank[target.bank_id].global_level)
+    softcut.level_cut_cut(target.bank_id +1,6,(target.right_delay_level*target.level)*bank[target.bank_id].global_level)
+  end
+  params:set("level "..target.bank_id,val,"true")
+  redraw()
+end
+
+function mc.adjust_bank_level(target,val)
+  bank[target.bank_id].global_level = util.linlin(0,127,0,2,val)
+  if target.envelope_mode == 2 or not target.enveloped then
+    softcut.level_slew_time(target.bank_id +1,1.0)
+    softcut.level(target.bank_id +1,target.level*bank[target.bank_id].global_level)
+    softcut.level_cut_cut(target.bank_id +1,5,(target.left_delay_level*target.level)*bank[target.bank_id].global_level)
+    softcut.level_cut_cut(target.bank_id +1,6,(target.right_delay_level*target.level)*bank[target.bank_id].global_level)
+  end
+  params:set("bank level "..target.bank_id,val,"true")
+  redraw()
+end
+
+function mc.redraw(target) -- expects (bank[x][y])
+  local duration = target.mode == 1 and 8 or clip[target.clip].sample_length
+  local min = target.mode == 1 and live[target.clip].min or clip[target.clip].min
+  local max = target.mode == 1 and live[target.clip].max or clip[target.clip].max
+  local start_to_cc = util.round(util.linlin(min,max,0,127,target.start_point))
+  midi_dev[params:get("midi_control_device")]:cc(1,start_to_cc,params:get("bank_"..target.bank_id.."_midi_channel"))
+  local end_to_cc = util.round(util.linlin(min,max,0,127,target.end_point))
+  midi_dev[params:get("midi_control_device")]:cc(2,end_to_cc,params:get("bank_"..target.bank_id.."_midi_channel"))
+  local tilt_to_cc = util.round(util.linlin(-1,1,0,127,target.tilt))
+  midi_dev[params:get("midi_control_device")]:cc(3,tilt_to_cc,params:get("bank_"..target.bank_id.."_midi_channel"))
+  local level_to_cc = util.round(util.linlin(0,2,0,127,target.level))
+  midi_dev[params:get("midi_control_device")]:cc(4,level_to_cc,params:get("bank_"..target.bank_id.."_midi_channel"))
+end
+
+function mc.cheat(target,note) -- expects (x,0-127)
+  bank[target].id = note
+  if not arp[target].playing then
+    selected[target].x = (5*(target-1)+1)+(math.ceil(bank[target].id/4)-1)
+    if (bank[target].id % 4) ~= 0 then
+      selected[target].y = 9-(bank[target].id % 4)
+    else
+      selected[target].y = 5
+    end
+    cheat(target,bank[target].id)
+    if params:get("midi_echo_enabled") == 2 then
+      mc.redraw(bank[target][bank[target].id])
+    end
+  end
+  grid_dirty = true
+  redraw()
+end
+
+function mc.zilch(target,note) -- expects (x,0-127)
+  if note == 1 or note == 2 then
+    for i = (note == 1 and bank[target].id or 1), (note == 1 and bank[target].id or 16) do
+      rightangleslice.actions[4]['134'][1](bank[target][i])
+      rightangleslice.actions[4]['134'][2](bank[target][i],target)
+    end
+  elseif note == 3 or note == 4 then
+    for i = (note == 3 and bank[target].id or 1), (note == 3 and bank[target].id or 16) do
+      rightangleslice.actions[4]['14'][1](bank[target][i])
+      rightangleslice.actions[4]['14'][2](bank[target][i],target)
+    end
+  elseif note == 5 or note == 6 then
+    for i = (note == 5 and bank[target].id or 1), (note == 5 and bank[target].id or 16) do
+      rightangleslice.actions[4]['124'][1](bank[target][i])
+      rightangleslice.actions[4]['124'][2](bank[target][i],target)
+    end
+  elseif note == 8 or note == 9 then
+    for i = (note == 8 and bank[target].id or 1), (note == 8 and bank[target].id or 16) do
+      bank[target][i].loop = not bank[target][i].loop
+    end
+    softcut.loop(target+1,bank[target][bank[target].id].loop == true and 1 or 0)
+  elseif note == 11 then
+    toggle_buffer(rec.clip)
+  elseif note == 13 or note == 14 then
+    for i = (note == 13 and bank[target].id or 1), (note == 13 and bank[target].id or 16) do
+      rightangleslice.actions[4]['12'][1](bank[target][i])
+      rightangleslice.actions[4]['12'][2](bank[target][i],target)
+    end
+  elseif note == 15 or note == 16 then
+    for i = (note == 15 and bank[target].id or 1), (note == 15 and bank[target].id or 16) do
+      rightangleslice.actions[4]['23'][1](bank[target][i])
+      rightangleslice.actions[4]['23'][2](bank[target][i],target)
+    end
+  elseif note == 17 or note == 18 then
+    for i = (note == 17 and bank[target].id or 1), (note == 17 and bank[target].id or 16) do
+      rightangleslice.actions[4]['34'][1](bank[target][i])
+      rightangleslice.actions[4]['34'][2](bank[target][i],target)
+    end
+  elseif note == 21 then
+    for i = 1,16 do
+      rightangleslice.actions[4]['2'][1](bank[target][i])
+      rightangleslice.actions[4]['2'][2](bank[target][i],target)
+    end
+  elseif note == 23 then
+    buff_flush()
+  end
+
+  if params:get("midi_echo_enabled") == 2 then
+    mc.redraw(bank[target][bank[target].id])
+  end
+
+  redraw()
+
+end
+
+return midicheat

--- a/lib/zilchmos.lua
+++ b/lib/zilchmos.lua
@@ -13,7 +13,7 @@ zilchmos.sc = {}
 --- main function
 
 -- this is the new zilchmos.init
-function zilchmos.init(k,i)
+function zilchmos.init(k,i,coll)
   -- for .help functionality
   which_bank = i -- FIXME should be in the help. namespace
   if menu == 11 then
@@ -24,8 +24,7 @@ function zilchmos.init(k,i)
   local b = bank[i] -- just alias for shorter lines
   local p = b.focus_hold and b.focus_pad or b.id -- was 'which_pad'
 
-  -- TODO fingers should be passed in as an argument, not globally accessed
-  local finger    = fingers[k][i].con
+  local finger    = coll
   local p_action  = z.actions[k][finger][1]
   local sc_action = z.actions[k][finger][2]
 


### PR DESCRIPTION
FIXED:
- midi mapping now accurately adjusts parameters in manual control PARAMS menu
- renamed "MIDI setup" to "MIDI keyboard setup" in PARAMS
- overall, improved [delays] menu nav
     - E1: switch between L and R
     - E2: navigate
     - E3: change value of selected parameter
     - K3: toggle between menu headers + parameters
     - K1: if the on-screen "feedback" param is selected, K1 hold time is 0.01, allowing performative delay cuts
- zilchmos used to run on metros, it was weird. this also meant that you couldn't execute two of the same row at the same time across banks. now, you can!
- added `recorded_zilch_zero(bank)` to turn off rad-sauce-recorded zilchmos
- longer-named collections now resize font when loading

ADDED:
- reduced K1 hold time to 0.1s globally
- standalone midicheat.lua file (housekeeping)
- grid controls for reverse delay (3,3 and 6,3)

WIP:
- began translating all LED levels to 4-step and grayscale, selectable in PARAMS > GRID > LED style (not yet completed)