### PR TITLE
patch 201119

### DIFF
--- a/cheat_codes_2.lua
+++ b/cheat_codes_2.lua
@@ -3840,7 +3840,7 @@ function grid_redraw()
       
       for i = 1,3 do
         if bank[i].focus_hold then
-          g:led(4*i,4,(10*bank[i][bank[i].focus_pad].crow_pad_execute)+5)
+          g:led(4+(5*(i-1)),4,(10*bank[i][bank[i].focus_pad].crow_pad_execute)+5)
         end
         -- if bank[i].focus_hold == true then
         --   g:led(5*i,5,(10*bank[i][bank[i].focus_pad].crow_pad_execute)+5)

--- a/cheat_codes_2.lua
+++ b/cheat_codes_2.lua
@@ -3839,12 +3839,17 @@ function grid_redraw()
       end
       
       for i = 1,3 do
-        if bank[i].focus_hold == true then
-          g:led(5*i,5,(10*bank[i][bank[i].focus_pad].crow_pad_execute)+5)
-        else
-          local alt = bank[i].alt_lock and 1 or 0
-          g:led(5*i,5,15*alt)
+        if bank[i].focus_hold then
+          g:led(4*i,4,(10*bank[i][bank[i].focus_pad].crow_pad_execute)+5)
         end
+        -- if bank[i].focus_hold == true then
+        --   g:led(5*i,5,(10*bank[i][bank[i].focus_pad].crow_pad_execute)+5)
+        -- else
+        --   local alt = bank[i].alt_lock and 1 or 0
+        --   g:led(5*i,5,15*alt)
+        -- end
+        local alt = bank[i].alt_lock and 1 or 0
+        g:led(5*i,5,15*alt)
       end
       
       for i,e in pairs(lit) do
@@ -4356,31 +4361,33 @@ arc_redraw = function()
     else
       which_pad = bank[arc_control[i]].focus_pad
     end
+
     local duration = bank[i][which_pad].mode == 1 and 8 or clip[bank[i][which_pad].clip].sample_length
     if arc_param[i] == 1 then
-      local start_to_led = (bank[arc_control[i]][which_pad].start_point-1)-(duration*(bank[arc_control[i]][which_pad].clip-1))
-      local end_to_led = (bank[arc_control[i]][which_pad].end_point-1)-(duration*(bank[arc_control[i]][which_pad].clip-1))
-      if start_to_led <= end_to_led then
-        a:segment(i, util.linlin(0, duration, tau*(1/4), tau*1.23, start_to_led), util.linlin(0, duration, (tau*(1/4))+0.1, tau*1.249999, end_to_led), 15)
-      else
-        a:segment(i, util.linlin(0, duration, (tau*(1/4))+0.1, tau*1.23, end_to_led), util.linlin(0, duration, tau*(1/4), tau*1.249999, start_to_led), 15)
-      end
+      -- if start_to_led <= end_to_led then
+      --   a:segment(i, util.linlin(0, duration, tau*(1/4), tau*1.23, start_to_led), util.linlin(0, duration, (tau*(1/4))+0.1, tau*1.249999, end_to_led), 15)
+      -- else
+      --   a:segment(i, util.linlin(0, duration, (tau*(1/4))+0.1, tau*1.23, end_to_led), util.linlin(0, duration, tau*(1/4), tau*1.249999, start_to_led), 15)
+      -- end
+
+      local minimum = bank[i][which_pad].mode == 1 and live[bank[i][which_pad].clip].min or clip[bank[i][which_pad].clip].min
+      local maximum = bank[i][which_pad].mode == 1 and live[bank[i][which_pad].clip].max or clip[bank[i][which_pad].clip].max
+      local start_to_led = bank[arc_control[i]][which_pad].start_point
+      local end_to_led = bank[arc_control[i]][which_pad].end_point
+      a:segment(i, util.linlin(minimum, maximum, tau*(1/4), tau*1.23, start_to_led), util.linlin(minimum, maximum, (tau*(1/4))+0.1, tau*1.249999, end_to_led), 15)
+      -- DOES THERE NEED TO BE AN ELSE CASE TO START < = END ???
+
     end
-    if arc_param[i] == 2 then
-      local start_to_led = (bank[arc_control[i]][which_pad].start_point-1)-(duration*(bank[arc_control[i]][which_pad].clip-1))
-      local end_to_led = (bank[arc_control[i]][which_pad].end_point-1)-(duration*(bank[arc_control[i]][which_pad].clip-1))
-      local playhead_to_led = util.linlin(1,(duration+1),1,64,(poll_position_new[i+1] - (duration*(bank[i][which_pad].clip-1))))
+    if arc_param[i] == 2 or arc_param[i] == 3 then
+      local minimum = bank[i][which_pad].mode == 1 and live[bank[i][which_pad].clip].min or clip[bank[i][which_pad].clip].min
+      local maximum = bank[i][which_pad].mode == 1 and live[bank[i][which_pad].clip].max or clip[bank[i][which_pad].clip].max
+      local start_to_led = math.floor(util.linlin(minimum,maximum,1,64,bank[arc_control[i]][which_pad].start_point))
+      local end_to_led = math.floor(util.linlin(minimum,maximum,1,64,bank[arc_control[i]][which_pad].end_point))
+      local playhead_to_led = util.linlin(minimum,maximum,1,64,poll_position_new[i+1])
       a:led(i,(math.floor(playhead_to_led))+16,5)
-      a:led(i,(math.floor(util.linlin(0,duration,1,64,start_to_led)))+16,15)
-      a:led(i,(math.floor(util.linlin(0,duration,1,64,end_to_led)))+17,8)
-    end
-    if arc_param[i] == 3 then
-      local start_to_led = (bank[arc_control[i]][which_pad].start_point-1)-(duration*(bank[arc_control[i]][which_pad].clip-1))
-      local end_to_led = (bank[arc_control[i]][which_pad].end_point-1)-(duration*(bank[arc_control[i]][which_pad].clip-1))
-      local playhead_to_led = util.linlin(1,(duration+1),1,64,(poll_position_new[i+1] - (duration*(bank[i][which_pad].clip-1))))
-      a:led(i,(math.floor(playhead_to_led))+16,5)
-      a:led(i,(math.floor(util.linlin(0,duration,1,64,end_to_led)))+17,15)
-      a:led(i,(math.floor(util.linlin(0,duration,1,64,start_to_led)))+16,8)
+      a:led(i, arc_param[i] == 2 and (start_to_led+16) or (end_to_led+17),15)
+      a:led(i, arc_param[i] == 2 and (end_to_led+17) or (start_to_led+16),8)
+
     end
     if arc_param[i] == 4 then
       local tilt_to_led = slew_counter[i].slewedVal

--- a/lib/arc_actions.lua
+++ b/lib/arc_actions.lua
@@ -113,7 +113,7 @@ function aa.move_window(target, delta)
     target.start_point = target.end_point - current_difference
   end
   if menu == 2 and page.loops_view[target.bank_id] == 4 and key1_hold then
-    update_content(2,target.start_point,target.end_point,128)
+    update_waveform(2,target.start_point,target.end_point,128)
   end
 end
 
@@ -130,7 +130,7 @@ function aa.move_start(target, delta)
     target.start_point = util.clamp(target.start_point+adjusted_delta,s_p,s_p+duration)
   end
   if menu == 2 and page.loops_view[target.bank_id] == 4 and key1_hold then
-    update_content(2,target.start_point,target.end_point,128)
+    update_waveform(2,target.start_point,target.end_point,128)
   end
 end
 
@@ -147,7 +147,7 @@ function aa.move_end(target, delta)
     target.end_point = util.clamp(target.end_point+adjusted_delta,s_p,s_p+duration)
   end
   if menu == 2 and page.loops_view[target.bank_id] == 4 and key1_hold then
-    update_content(2,target.start_point,target.end_point,128)
+    update_waveform(2,target.start_point,target.end_point,128)
   end
 
 end

--- a/lib/encoder_actions.lua
+++ b/lib/encoder_actions.lua
@@ -559,14 +559,15 @@ function encoder_actions.init(n,d)
         if not key1_hold then
           if page_line[pattern_page] == 1 then
             page.time_arc_loop[pattern_page-3] = util.clamp(page.time_arc_loop[pattern_page-3]+d,1,3)
-            if g.device == nil then
+            -- if g.device == nil then
               arc_param[pattern_page-3] = page.time_arc_loop[pattern_page-3]
-            end
+              grid_dirty = true
+            -- end
           end
         else
-          if page.page_line_sel[page.time_sel] <= 4 then
+          if page.time_page_sel[page.time_sel] <= 4 then
             local id = page.time_sel-3
-            local val = page.page_line_sel[page.time_sel]
+            local val = page.time_page_sel[page.time_sel]
             arc_pat[id][val].time_factor = util.clamp(arc_pat[id][val].time_factor + d/10,0.1,10)
           end
         end

--- a/lib/grid_actions.lua
+++ b/lib/grid_actions.lua
@@ -116,7 +116,7 @@ function grid_actions.init(x,y,z)
     
     -- zilchmo 3+4 handling
     if x == 4 or x == 5 or x == 9 or x == 10 or x == 14 or x == 15 then
-      if y <= 4 then
+      if ((x == 4 or x == 9 or x == 14) and y <= 3) or ((x == 5 or x == 10 or x == 15) and y <= 4) then
         local zilch_id = x%5 == 0 and 4 or 3
         local zmap = zilches[zilch_id]
         local k1 = util.round(x/5)
@@ -451,20 +451,21 @@ function grid_actions.init(x,y,z)
     end
     
     if y == 5 then
-      if z == 1 then
-        for i = 1,3 do
-          if bank[i].focus_hold == true then
-            if x == i*5 then
-              bank[i][bank[i].focus_pad].crow_pad_execute = (bank[i][bank[i].focus_pad].crow_pad_execute + 1)%2
-              if grid.alt then
-                for j = 1,16 do
-                  bank[i][j].crow_pad_execute = bank[i][bank[i].focus_pad].crow_pad_execute
-                end
-              end
-            end
-          end
-        end
-      end
+      --CROW
+      -- if z == 1 then
+      --   for i = 1,3 do
+      --     if bank[i].focus_hold == true then
+      --       if x == i*5 then
+      --         bank[i][bank[i].focus_pad].crow_pad_execute = (bank[i][bank[i].focus_pad].crow_pad_execute + 1)%2
+      --         if grid.alt then
+      --           for j = 1,16 do
+      --             bank[i][j].crow_pad_execute = bank[i][bank[i].focus_pad].crow_pad_execute
+      --           end
+      --         end
+      --       end
+      --     end
+      --   end
+      -- end
       if x == 5 or x == 10 or x == 15 then
         if not grid.alt then
           bank[x/5].alt_lock = z == 1 and true or false
@@ -489,8 +490,8 @@ function grid_actions.init(x,y,z)
             else
               if key1_hold == true then key1_hold = false end
               if y == 4 then
-                menu = 2
-                page.loops_sel = math.floor((x/4))
+                --CROW
+                bank[i][bank[i].focus_pad].crow_pad_execute = (bank[i][bank[i].focus_pad].crow_pad_execute + 1)%2
               end
               if menu ~= 1 then screen_dirty = true end
             end
@@ -501,15 +502,20 @@ function grid_actions.init(x,y,z)
             if y == 3 then
               grid_actions.kill_arp(i)
             end
-            if y == 4 then
+            if y == 4 and not bank[i].focus_hold then
               local current = math.floor(x/5)+1
-              for i = 1,16 do
-                bank[current][i].rate = 1
-                if bank[current][i].fifth == true then
-                  bank[current][i].fifth = false
+              for j = 1,16 do
+                bank[current][j].rate = 1
+                if bank[current][j].fifth == true then
+                  bank[current][j].fifth = false
                 end
               end
               softcut.rate(current+1,1*bank[current][bank[current].id].offset)
+            elseif y == 4 and bank[i].focus_hold then
+              bank[i][bank[i].focus_pad].crow_pad_execute = (bank[i][bank[i].focus_pad].crow_pad_execute + 1)%2
+              for j = 1,16 do
+                bank[i][j].crow_pad_execute = bank[i][bank[i].focus_pad].crow_pad_execute
+              end
             end
           end
           ---


### PR DESCRIPTION
fixes:

**arc**  
- arc LEDs now scale appropriately across all buffers (thank you @swhic!)
- arc movements now update waveform
- arc pattern recorder can switch between foci
  - E2 on timing > arc patterns > loop(w) switches between loop(w), loop(s), and loop(e)
- arc pattern playback can have variable rate
  - after recording an arc pattern, hold K1 on timing > arc patterns to reveal pattern playback rate
  - use E3 while holding K1 to adjust playback rate (1/10th speed to 10x)

**grid**
- 1x works on all pads in non-focus mode
- focus hold unlocks crow pad toggle
  - bright key next to zilchmo 3 when in focus hold mode
  - determines whether a pad execution should send a pulse out of the crow output, if timing > pad pattern > crow pulse is set to `pads`)
- fixed some local alt issues (thank you @bloc!)