### PR TITLE
update 201126

### DIFF
--- a/cheat_codes_2.lua
+++ b/cheat_codes_2.lua
@@ -1997,7 +1997,11 @@ function one_shot_clock()
     local rate = divs[params:get("one_shot_clock_div")]
     clock.sync(rate)
   end
-  softcut.position(1,rec[rec.focus].start_point+0.1) -- TODO CLARIFY IF THIS IS REAL ANYMORE
+  -- softcut.loop_start(1,rec[rec.focus].start_point-0.05)
+  softcut.loop_start(1,rec[rec.focus].start_point-(params:get("one_shot_latency_offset")))
+  softcut.loop_end(1,rec[rec.focus].end_point-0.01)
+  softcut.position(1,rec[rec.focus].start_point-((params:get("one_shot_latency_offset")-0.01))) -- TODO CLARIFY IF THIS IS REAL ANYMORE
+  -- softcut.position(1,rec[rec.focus].start_point+0.01)
   rec.play_segment = rec.focus
   softcut.rec_level(1,1)
   rec[rec.focus].state = 1
@@ -4862,6 +4866,11 @@ function persistent_state_save()
     io.write("bank_"..i.."_midi_zilchmo_enabled: "..params:get("bank_"..i.."_midi_zilchmo_enabled").."\n")
   end
   io.write("grid_size: "..params:get("grid_size").."\n")
+  -- io.write("rec_loop_1: "..params:get("rec_loop_1").."\n")
+  -- io.write("rec_loop_2: "..params:get("rec_loop_2").."\n")
+  -- io.write("rec_loop_3: "..params:get("rec_loop_3").."\n")
+  -- io.write("one_shot_clock_div: "..params:get("one_shot_clock_div").."\n")
+  -- io.write("rec_loop_enc_resolution: "..params:get("rec_loop_enc_resolution").."\n")
   io.close(file)
 end
 

--- a/cheat_codes_2.lua
+++ b/cheat_codes_2.lua
@@ -745,6 +745,8 @@ function init()
   rec.loop = 1
   rec.clear = 0
   rec.rate_offset = 1.0
+  rec.stopped = false
+  rec.play_segment = 1
 
   rec.focus = 1
 
@@ -761,11 +763,20 @@ function init()
     rec[i].waveform_samples = {}
   end
 
-  params:add_group("GRID",1)
+  params:add_group("GRID",2)
   params:add_option("LED_style","LED style",{"varibright","4-step","grayscale"},1)
   params:set_action("LED_style",
   function()
     grid_dirty = true
+    if all_loaded then
+      persistent_state_save()
+    end
+  end)
+  params:add_option("grid_size","grid size",{"128","64"},1)
+  params:set_action("grid_size",
+  function()
+    grid_dirty = true
+    params:set("LED_style",2)
     if all_loaded then
       persistent_state_save()
     end
@@ -955,12 +966,17 @@ function init()
   params:default()
   
   grid_page = 0
+  grid_page_64 = 0
+  bank_64 = 1
   
   page = {}
   page.loops = {}
   page.loops.frame = 1
   page.loops.sel = 1
+  page.loops.meta_sel = 1
+  page.loops.meta_option_set = {1,1,1,1}
   page.loops.top_option_set = {1,1,1,1}
+  page.loops.focus_hold = {false, false, false, false}
   page.main_sel = 1
   page.loops_sel = 1
   page.loops_page = 0
@@ -1133,9 +1149,10 @@ function init()
         if rec[rec.focus].end_point < poll_position_new[1] +0.015 then
           rec[rec.focus].state = 0
           rec_state_watcher:stop()
+          rec.stopped = true
           grid_dirty = true
           if menu == 2 then
-            if menu ~= 1 then screen_dirty = true end
+            if page.loops.sel ~= 5 then screen_dirty = true end
             -- print("stopped")
           end
         end
@@ -1948,15 +1965,15 @@ function random_rec_clock()
     local rler = rec_loop_enc_resolution
     local rec_distance = rec[rec.focus].end_point - rec[rec.focus].start_point
     local bar_count = params:get("rec_loop_enc_resolution") > 2 and (((rec_distance)/(1/rler)) / (rler))*(2*lbr[params:get("live_buff_rate")]) or 1/4
-    clock.sync(params:get("rec_loop") == 1 and 4 or bar_count)
+    clock.sync(params:get("rec_loop_"..rec.focus) == 1 and 4 or bar_count)
     local random_rec_prob = params:get("random_rec_clock_prob")
     if random_rec_prob > 0 then
       local random_rec_comp = math.random(0,100)
       if random_rec_comp < random_rec_prob then
-        if params:get("rec_loop") == 1 then
+        if params:get("rec_loop_"..rec.focus) == 1 then
           buff_freeze()
           grid_dirty = true
-        elseif params:get("rec_loop") == 2 then
+        elseif params:get("rec_loop_"..rec.focus) == 2 then
           if not rec_state_watcher.is_running then
             softcut.position(1,rec[rec.focus].start_point+0.1)
             softcut.rec_level(1,1)
@@ -1980,9 +1997,11 @@ function one_shot_clock()
     local rate = divs[params:get("one_shot_clock_div")]
     clock.sync(rate)
   end
-  softcut.position(1,rec[rec.focus].start_point+0.1)
+  softcut.position(1,rec[rec.focus].start_point+0.1) -- TODO CLARIFY IF THIS IS REAL ANYMORE
+  rec.play_segment = rec.focus
   softcut.rec_level(1,1)
   rec[rec.focus].state = 1
+  rec.stopped = false
   rec_state_watcher:start()
   if rec[rec.focus].clear == 1 then rec[rec.focus].clear = 0 end
   grid_dirty = true
@@ -2272,7 +2291,8 @@ phase = function(n, x)
         update_waveform(1,key1_hold and rec[rec.focus].start_point or live[rec_on].min,key1_hold and rec[rec.focus].end_point or live[rec_on].max,128)
       end
     end
-    if menu ~= 1 then screen_dirty = true end
+    screen_dirty = true
+    -- if page.loops.sel ~= 5 then screen_dirty = true end
   end
 end
 
@@ -2584,7 +2604,8 @@ function cheat(b,i)
       pad.fifth = true
     end
   end
-  params:set("current pad "..tonumber(string.format("%.0f",b)),i,"true")
+  -- params:set("current pad "..tonumber(string.format("%.0f",b)),i,"true")
+  mc.params_redraw(pad)
   if osc_communication == true then
     osc_redraw(b)
   end
@@ -2848,6 +2869,12 @@ function toggle_buffer(i)
   softcut.fade_time(1,0.01)
   
   local old_clip = rec.focus
+
+  for j = 1,3 do
+    if j ~= i then
+      rec[j].state = 0
+    end
+  end
   
   -- for go = 1,2 do
   --   local old_min = (1+(8*(rec.focus-1)))
@@ -2868,10 +2895,20 @@ function toggle_buffer(i)
     clock.run(one_shot_clock)
   elseif rec[rec.focus].loop == 0 and grid.alt then
     buff_flush()
+  -- elseif rec[rec.focus].loop == 1 and not grid.alt then
+  --   softcut.position(1,rec[rec.focus].start_point)
   end
   
   softcut.loop_start(1,rec[rec.focus].start_point)
   softcut.loop_end(1,rec[rec.focus].end_point-0.01)
+  rec.play_segment = rec.focus
+  softcut.loop(1,rec[rec.focus].loop)
+  if rec.stopped == true then
+    rec.stopped = false
+    if rec[rec.focus].loop == 1 then
+      softcut.position(1,rec[rec.focus].start_point)
+    end
+  end
   if rec[rec.focus].loop == 1 then
     if old_clip ~= rec.focus then rec[rec.focus].state = 0 end
     buff_freeze()
@@ -3023,6 +3060,12 @@ function key(n,z)
             end
           elseif page.loops.sel == 4 then
             toggle_buffer(rec.focus)
+          elseif page.loops.sel == 5 then
+            if page.loops.meta_sel < 4 then
+              for i = 1,16 do
+                rightangleslice.end_sixteenths(bank[page.loops.meta_sel][i])
+              end
+            end
           end
           grid_dirty = true
           key2_hold_and_modify = true
@@ -3058,6 +3101,24 @@ function key(n,z)
             end
           elseif page.loops.sel == 4 and page.loops.frame == 2 then
             -- something else
+          elseif page.loops.sel == 5 and page.loops.frame == 2 then
+            if page.loops.meta_sel < 4 then
+              -- sync to next
+              local id = page.loops.meta_sel
+              local src_bank_num = (id == 1 or id == 2) and 3 or 2
+              local src_bank     = bank[src_bank_num]
+              local src_pad      = src_bank[src_bank.id]
+              -- -- shift start/end by the difference between clips
+              local reasonable_max = bank[id][bank[id].id].mode == 1 and 8 or clip[bank[id][bank[id].id].clip].sample_length
+              if src_pad.end_point <= reasonable_max then
+                bank[id][bank[id].id].start_point = src_pad.start_point
+                bank[id][bank[id].id].end_point = src_pad.end_point
+                rightangleslice.sc.start_end( bank[id][bank[id].id], id )
+                -- if bank[id][bank[id].id].loop then
+                --   softcut.position(id+1, bank[id][bank[id].id].start_point )
+                -- end
+              end
+            end
           end
         end
       elseif menu == 3 then
@@ -3264,8 +3325,25 @@ function key(n,z)
         if page.loops.frame == 2 and key1_hold then
           if page.loops.sel == 4 then
             buff_flush()
-          else
+          elseif page.loops.sel < 4 then
             sync_clock_to_loop(bank[page.loops.sel][bank[page.loops.sel].id],"audio")
+          elseif page.loops.sel == 5 then
+            if page.loops.meta_sel < 4 then
+              -- THIS SHOULD CHECK TO SEE IF PAD LOCKED...
+              -- sync to next
+              local id = page.loops.meta_sel
+              local src_bank_num = id == 1 and 2 or 1
+              local src_bank     = bank[src_bank_num]
+              local src_pad      = src_bank[src_bank.id]
+              -- -- shift start/end by the difference between clips
+              local reasonable_max = bank[id][bank[id].id].mode == 1 and 8 or clip[bank[id][bank[id].id].clip].sample_length
+              if src_pad.end_point <= reasonable_max then
+                bank[id][bank[id].id].start_point = src_pad.start_point
+                bank[id][bank[id].id].end_point = src_pad.end_point
+                rightangleslice.sc.start_end( bank[id][bank[id].id], id )
+                -- softcut.position(id+1, bank[id][bank[id].id].start_point )
+              end
+            end
           end
         end
       end
@@ -3315,7 +3393,7 @@ function key(n,z)
         if page.loops.frame == 2 and key1_hold then
           if page.loops.sel == 4 then
             buff_flush()
-          else
+          elseif page.loops.sel < 4 then
             sync_clock_to_loop(bank[page.loops.sel][bank[page.loops.sel].id],"audio")
           end
         -- if key1_hold and page.loops_sel ~= 4 then
@@ -3389,6 +3467,22 @@ function key(n,z)
           end
         elseif menu == 2 and page.loops.sel == 4 and page.loops.frame == 2 then
           update_waveform(1,rec[rec.focus].start_point,rec[rec.focus].end_point,128)
+        elseif menu == 2 and page.loops.sel == 5 and page.loops.frame == 2 then
+          if not key2_hold then
+            local id = page.loops.meta_sel
+            if id < 4 and (grid_pat[id].play == 1 or midi_pat[id].play == 1 or arp[id].playing or rytm.track[id].k ~= 0) then
+              bank[id].focus_pad = bank[id].id
+            -- page.loops.focus_hold[page.loops.meta_sel] = not page.loops.focus_hold[page.loops.meta_sel]
+            end
+          elseif key2_hold then
+            if page.loops.meta_sel < 4 then
+              print("should slice")
+              for i = 1,16 do
+                rightangleslice.start_end_default(bank[page.loops.meta_sel][i])
+              end
+              key1_hold = false -- right??
+            end
+          end
         end
       end
       
@@ -3646,7 +3740,7 @@ led_maps =
   -- main page
   ["square_off"]          =   {3,4,15}
   , ["square_selected"]   =   {15,15,0}
-  , ["square_dim"]        =   {5,4,0}
+  , ["square_dim"]        =   {5,8,0}
   , ["zilchmo_off"]       =   {3,4,15} -- is this right?
   , ["zilchmo_on"]        =   {15,12,0}
   , ["pad_pause"]         =   {15,12,15}
@@ -3670,12 +3764,13 @@ led_maps =
   , ["arp_on"]            =   {4,4,0}
   , ["arp_pause"]         =   {4,8,15}
   , ["arp_play"]          =   {10,12,15}
-  , ["live_empty"]        =   {3,0,0}
-  , ["live_rec"]          =   {10,8,15}
-  , ["live_pause"]        =   {5,4,0}
+  , ["live_empty"]        =   {3,4,0}
+  , ["live_rec"]          =   {10,12,15}
+  , ["live_pause"]        =   {5,8,0}
   , ["alt_on"]            =   {15,12,15}
   , ["alt_off"]           =   {3,4,0}
   , ["focus_on"]          =   {10,8,15}
+  -- , ["focus_soft"]        =   {10,8,15}
 
   -- seq page
   , ["step_no_data"]      =   {2,4,0}
@@ -3712,6 +3807,7 @@ led_maps =
   , ["level_hi"]          =   {7,8,15}
   , ["selected_bank"]     =   {7,8,15}
   , ["unselected_bank"]   =   {2,4,0}
+  , ["64_bank_send"]      =   {4,8,15}
   
   -- misc
   , ["page_led"]          =   {{0,0,15},{7,8,15},{15,12,15}}
@@ -3724,455 +3820,749 @@ end
 
 function grid_redraw()
   if g.device ~= nil then
-    g:all(0)
-    local edition = params:get("LED_style")
-    
-    if grid_page == 0 then
+    if params:string("grid_size") == "128" then
+      g:all(0)
+      local edition = params:get("LED_style")
       
-      for j = 0,2 do
-        for k = 1,4 do
-          k = k+(5*j)
-          for i = 8,5,-1 do
+      if grid_page == 0 then
+        
+        for j = 0,2 do
+          for k = 1,4 do
+            k = k+(5*j)
+            for i = 8,5,-1 do
+              g:led(k,i,led_maps["square_off"][edition])
+            end
+          end
+        end
+        
+        for i = 0,1 do
+          for x = 4+i,14+i,5 do
+            for j = 1,3+i do
+              g:led(x,j,zilch_leds[i == 0 and 3 or 4][util.round(x/5)][j] == 1 and led_maps["zilchmo_on"][edition] or led_maps["zilchmo_off"][edition])
+            end
+          end
+        end
+
+        for x = 3,13,5 do
+          for j = 1,2 do
+            g:led(x,j,zilch_leds[2][util.round(x/5)][j] == 1 and led_maps["zilchmo_on"][edition] or led_maps["zilchmo_off"][edition])
+          end
+        end
+        
+        for i = 1,3 do
+          local target = grid_pat[i]
+          if target.rec == 1 then
+            g:led(2+(5*(i-1)),1,(9*target.led))
+          elseif (target.quantize == 0 and target.play == 1) or (target.quantize == 1 and target.tightened_start == 1) then
+            if target.overdub == 0 then
+              g:led(2+(5*(i-1)),1,9)
+            else
+              g:led(2+(5*(i-1)),1,15)
+            end
+          elseif target.count > 0 then
+            g:led(2+(5*(i-1)),1,5)
+          else
+            g:led(2+(5*(i-1)),1,3)
+          end
+        end
+        
+        for i = 1,3 do
+          local a_p; -- this will index the arc encoder recorders
+          if arc_param[i] == 1 or arc_param[i] == 2 or arc_param[i] == 3 then
+            a_p = 1
+          else
+            a_p = arc_param[i] - 2
+          end
+          if arc_pat[i][a_p].rec == 1 then
+            g:led(16,5-i,led_maps["arc_rec_rec"][edition])
+          elseif arc_pat[i][a_p].play == 1 then
+            g:led(16,5-i,led_maps["arc_rec_play"][edition])
+          elseif arc_pat[i][a_p].count > 0 then
+            g:led(16,5-i,led_maps["arc_rec_pause"][edition])
+          else
+            g:led(16,5-i,led_maps["arc_rec_off"][edition])
+          end
+        end
+        
+        if a.device ~= nil then
+          for i = 1,3 do
+            for j = 5,15,5 do
+              g:led(j,8,arc_param[j/5] == 1 and 5 or 0)
+              g:led(j,7,arc_param[j/5] == 2 and 5 or 0)
+              g:led(j,6,arc_param[j/5] == 3 and 5 or 0)
+              if arc_param[j/5] == 4 then
+                for k = 8,6,-1 do
+                  g:led(j,k,led_maps["arc_param_show"][edition])
+                end
+              elseif arc_param[j/5] == 5 then
+                g:led(j,8,led_maps["arc_param_show"][edition])
+                g:led(j,7,led_maps["arc_param_show"][edition])
+              elseif arc_param[j/5] == 6 then
+                g:led(j,7,led_maps["arc_param_show"][edition])
+                g:led(j,6,led_maps["arc_param_show"][edition])
+              end
+            end
+          end
+        end
+        
+        for i = 1,3 do
+          if bank[i].focus_hold == false then
+            g:led(selected[i].x, selected[i].y, led_maps["square_selected"][edition])
+            if i == nil then print("2339") end
+            if bank[i].id == nil then print("2340", i) end
+            if bank[i][bank[i].id].pause == nil then print("2341") end
+            if bank[i][bank[i].id].pause == true then
+              g:led(3+(5*(i-1)),1,led_maps["pad_pause"][edition])
+              g:led(3+(5*(i-1)),2,led_maps["pad_pause"][edition])
+            else
+              -- g:led(3+(5*(i-1)),1,led_maps["pad_play"][edition])
+              -- g:led(3+(5*(i-1)),2,led_maps["pad_play"][edition])
+              g:led(3+(5*(i-1)),1,zilch_leds[2][i][1] == 1 and led_maps["zilchmo_on"][edition] or led_maps["zilchmo_off"][edition])
+              g:led(3+(5*(i-1)),2,zilch_leds[2][i][2] == 1 and led_maps["zilchmo_on"][edition] or led_maps["zilchmo_off"][edition])
+            end
+          else
+            local focus_x = (math.ceil(bank[i].focus_pad/4)+(5*(i-1)))
+            local focus_y = 8-((bank[i].focus_pad-1)%4)
+            g:led(selected[i].x, selected[i].y, led_maps["square_dim"][edition])
+            g:led(focus_x, focus_y, led_maps["square_selected"][edition])
+            if bank[i][bank[i].focus_pad].pause == true then
+              g:led(3+(5*(i-1)),1,led_maps["square_selected"][edition])
+              g:led(3+(5*(i-1)),2,led_maps["square_selected"][edition])
+            else
+              g:led(3+(5*(i-1)),1,led_maps["square_off"][edition])
+              g:led(3+(5*(i-1)),2,led_maps["square_off"][edition])
+            end
+          end
+        end
+        
+        for i = 1,3 do
+          if bank[i].focus_hold then
+            g:led(4+(5*(i-1)),4,(10*bank[i][bank[i].focus_pad].crow_pad_execute)+5)
+          end
+          -- if bank[i].focus_hold == true then
+          --   g:led(5*i,5,(10*bank[i][bank[i].focus_pad].crow_pad_execute)+5)
+          -- else
+          --   local alt = bank[i].alt_lock and 1 or 0
+          --   g:led(5*i,5,15*alt)
+          -- end
+          local alt = bank[i].alt_lock and 1 or 0
+          g:led(5*i,5,15*alt)
+        end
+        
+        for i,e in pairs(lit) do
+          g:led(e.x, e.y,led_maps["zilchmo_on"][edition])
+        end
+        
+        g:led(16,8,(grid.alt and led_maps["alt_on"][edition] or led_maps["alt_off"][edition]))
+        
+        for i = 1,3 do
+          
+          local focused = bank[i].focus_hold == false and bank[i][bank[i].id] or bank[i][bank[i].focus_pad]
+
+          g:led(1 + (5*(i-1)), math.abs(focused.clip-5),led_maps["clip"][edition])
+          g:led(2 + (5*(i-1)), math.abs(focused.mode-5),led_maps["mode"][edition])
+          g:led(1+(5*(i-1)),1,bank[i].focus_hold == false and led_maps["off"][edition] or led_maps["focus_on"][edition])
+          if focused.loop == false then
+            g:led(3+(5*(i-1)),4,led_maps["loop_off"][edition])
+          elseif focused.loop == true then
+            g:led(3+(5*(i-1)),4,led_maps["loop_on"][edition])
+          end
+          if not arp[i].enabled then
+            g:led(3+(5*(i-1)),3,led_maps["off"][edition])
+          else
+            if arp[i].playing and arp[i].hold then
+              g:led(3+(5*(i-1)),3,led_maps["arp_play"][edition])
+            elseif arp[i].hold then
+              g:led(3+(5*(i-1)),3,led_maps["arp_pause"][edition])
+            else
+              g:led(3+(5*(i-1)),3,led_maps["arp_on"][edition])
+            end
+          end
+
+        end
+        
+        if rec[rec.focus].clear == 0 then
+          g:led(16,8-rec.focus,rec[rec.focus].state == 1 and led_maps["live_rec"][edition] or led_maps["live_pause"][edition])
+        elseif rec[rec.focus].clear == 1 then
+          g:led(16,8-rec.focus,led_maps["live_empty"][edition])
+        end
+      
+      elseif grid_page == 1 then
+        
+        -- if we're on page 2...
+        
+        for i = 1,3 do
+
+          for j = step_seq[i].start_point,step_seq[i].end_point do
+            local xval = j < 9 and (i*5)-2 or (i*5)-1
+            local yval = j < 9 and 9 or 17
+
+            g:led(xval,yval-j,led_maps["step_no_data"][edition])
+
+            if grid.loop_mod == 1 then
+              g:led(xval,yval-step_seq[i].start_point,led_maps["step_loops"][edition])
+              g:led(xval,yval-step_seq[i].end_point,led_maps["step_loops"][edition])
+            end
+
+          end
+
+          for j = 1,16 do
+            if step_seq[i][j].assigned_to ~= 0 then
+              local xval = j < 9 and (i*5)-2 or (i*5)-1
+              local yval = j < 9 and 9 or 17
+              g:led(xval,yval-j,led_maps["step_yes_data"][edition])
+            end
+          end
+
+          if step_seq[i].current_step < 9 then
+            g:led((i*5)-2,9-step_seq[i].current_step,led_maps["step_current"][edition])
+          elseif step_seq[i].current_step >=9 then
+            g:led((i*5)-1,9-(step_seq[i].current_step-8),led_maps["step_current"][edition])
+          end
+
+          if step_seq[i].held < 9 then
+            g:led((i*5)-2,9-step_seq[i].held,led_maps["step_held"][edition])
+          elseif step_seq[i].held >= 9 then
+            g:led((i*5)-1,9-(step_seq[i].held-8),led_maps["step_held"][edition])
+          end
+
+          g:led((i*5)-3, 9-step_seq[i].meta_duration,led_maps["meta_duration"][edition])
+          g:led((i*5)-3, 9-step_seq[i].meta_step,led_maps["meta_step_hi"][edition])
+
+          if step_seq[i].held == 0 then
+            g:led((i*5), 9-step_seq[i][step_seq[i].current_step].meta_meta_duration,led_maps["meta_duration"][edition])
+            g:led((i*5), 9-step_seq[i].meta_meta_step,led_maps["meta_step_hi"][edition])
+          else
+            g:led((i*5), 9-step_seq[i].meta_meta_step,led_maps["meta_step_lo"][edition])
+            g:led((i*5), 9-step_seq[i][step_seq[i].held].meta_meta_duration,led_maps["meta_duration"][edition])
+          end
+          if step_seq[i].held == 0 then
+            g:led(16,8-i,edition == 3 and (15*step_seq[i].active) or ((step_seq[i].active*6)+2))
+          else
+            g:led(16,8-i,step_seq[i][step_seq[i].held].loop_pattern*4)
+          end
+
+        end
+        
+        for i = 1,11,5 do
+          for j = 1,8 do
+            local current = math.floor(i/5)+1
+            local show = step_seq[current].held == 0 and pattern_saver[current].load_slot or step_seq[current][step_seq[current].held].assigned_to
+            g:led(i,j,edition == 3 and (15*pattern_saver[current].saved[9-j]) or ((5*pattern_saver[current].saved[9-j])+2))
+            g:led(i,j,j == (9 - show) and 15 or (edition == 3 and (15*pattern_saver[current].saved[9-j]) or ((5*pattern_saver[current].saved[9-j])+2)))
+          end
+        end
+        
+        g:led(16,8,grid.alt and led_maps["alt_on"][edition] or led_maps["alt_off"][edition])
+        g:led(16,2,grid.loop_mod == 1 and led_maps["loop_mod_hi"][edition] or led_maps["loop_mod_lo"][edition])
+      
+      elseif grid_page == 2 then
+        -- delay page!
+        for i = 1,8 do
+          local check = {i+8, i}
+          for j = 1,2 do
+            g:led(i,j,delay[2].selected_bundle == check[j] and 15 or (delay_bundle[2][check[j]].saved == true and led_maps["bundle_saved"][edition] or led_maps["bundle_empty"][edition]))
+            g:led(i,j+6,delay[1].selected_bundle == check[j] and 15 or (delay_bundle[1][check[j]].saved == true and led_maps["bundle_saved"][edition] or led_maps["bundle_empty"][edition]))
+          end
+        end
+
+        -- delay time modifiers
+        local time_to_led = {{},{},{},{}}
+        local time = {delay[1].modifier, delay[2].modifier}
+        for i = 1,2 do
+          time_to_led[i] = 0
+          time_to_led[i+2] = 0
+          if time[i] == 0.5 then
+            time_to_led[i+2] = led_maps["time_to_led.5"][edition]
+          elseif time[i] == 0.25 then
+            time_to_led[i+2] = led_maps["time_to_led.25"][edition]
+          elseif time[i] == 0.125 then
+            time_to_led[i+2] = led_maps["time_to_led.125"][edition]
+          elseif time[i] == 2 then
+            time_to_led[i] = led_maps["time_to_led2"][edition]
+          elseif time[i] == 4 then
+            time_to_led[i] = led_maps["time_to_led4"][edition]
+          elseif time[i] == 8 then
+            time_to_led[i] = led_maps["time_to_led8"][edition]
+          elseif time[i] == 16 then
+            time_to_led[i] = led_maps["time_to_led16"][edition]
+          end
+        end
+        g:led(1,3,time_to_led[2])
+        g:led(2,3,time_to_led[4])
+        g:led(1,6,time_to_led[1])
+        g:led(2,6,time_to_led[3])
+        g:led(3,3,delay[2].reverse and led_maps["reverse_on"][edition] or led_maps["reverse_off"][edition])
+        g:led(3,6,delay[1].reverse and led_maps["reverse_on"][edition] or led_maps["reverse_off"][edition])
+
+        rate_to_led = {{},{},{},{}}
+        local rate = {params:get("delay L: rate"), params:get("delay R: rate")}
+        for i = 1,2 do
+          rate_to_led[i] = 0
+          rate_to_led[i+2] = 0
+          for j = 1,24 do
+            if math.modf(rate[i]) >= j then
+              rate_to_led[i] = math.modf(util.linlin(0,24,3,15,j))
+            end
+          end
+          for j = 0.25,1,0.05 do
+            if rate[i] >= j then
+              rate_to_led[i+2] = math.modf(util.linlin(0.25,1,15,0,j))
+            end
+          end
+          if rate[i] == 1 then
+            rate_to_led[i+2] = 3
+          end
+        end
+        g:led(1,4,rate_to_led[2])
+        g:led(2,4,rate_to_led[4])
+        g:led(3,4,delay[2].wobble_hold and led_maps["wobble_on"][edition] or led_maps["wobble_off"][edition])
+        g:led(1,5,rate_to_led[1])
+        g:led(2,5,rate_to_led[3])
+        g:led(3,5,delay[1].wobble_hold and led_maps["wobble_on"][edition] or led_maps["wobble_off"][edition])
+        
+        -- delay levels
+        local level_to_led = {{},{}}
+        local delay_level = {params:get("delay L: global level"), params:get("delay R: global level")}
+        for i = 1,2 do
+          if delay_level[i] <= 0.125 then
+            level_to_led[i] = 0
+          elseif delay_level[i] <= 0.375 then
+            level_to_led[i] = 1
+          elseif delay_level[i] <= 0.625 then
+            level_to_led[i] = 2
+          elseif delay_level[i] <= 0.875 then
+            level_to_led[i] = 3
+          elseif delay_level[i] <= 1 then
+            level_to_led[i] = 4
+          end
+        end
+        for i = 8,4,-1 do
+          g:led(i,6,led_maps["level_lo"][edition])
+          g:led(i,3,led_maps["level_lo"][edition])
+        end
+        for i = 1,2 do
+          if not delay[i].level_mute then
+            for j = 8,4+(4-level_to_led[i]),-1 do
+              g:led(j,i==1 and 6 or 3,led_maps["level_hi"][edition])
+            end
+          else
+            if params:get(i == 1 and "delay L: global level" or "delay R: global level") == 0 then
+              for j = 8,4,-1 do
+                g:led(j,i==1 and 6 or 3,led_maps["level_hi"][edition])
+              end
+            end
+          end
+        end
+
+        -- feedback levels
+        local feed_to_led = {{},{}}
+        local feedback_level = {params:get("delay L: feedback"), params:get("delay R: feedback")}
+        for i = 1,2 do
+          if feedback_level[i] <= 12.5 then
+            feed_to_led[i] = 0
+          elseif feedback_level[i] <= 37.5 then
+            feed_to_led[i] = 1
+          elseif feedback_level[i] <= 62.5 then
+            feed_to_led[i] = 2
+          elseif feedback_level[i] <= 87.5 then
+            feed_to_led[i] = 3
+          elseif feedback_level[i] <= 100 then
+            feed_to_led[i] = 4
+          end
+        end
+        for i = 8,4,-1 do
+          g:led(i,5,led_maps["level_lo"][edition])
+          g:led(i,4,led_maps["level_lo"][edition])
+        end
+        for i = 1,2 do
+          if not delay[i].feedback_mute then
+            for j = 8,4+(4-feed_to_led[i]),-1 do
+              g:led(j,i==1 and 5 or 4,led_maps["level_hi"][edition])
+            end
+          else
+            if params:get(i == 1 and "delay L: feedback" or "delay R: feedback") == 0 then
+              for j = 8,4,-1 do
+                g:led(j,i==1 and 5 or 4,led_maps["level_hi"][edition])
+              end
+            end
+          end
+        end
+
+        for k = 10,13 do
+          for i = 6,3,-1 do
             g:led(k,i,led_maps["square_off"][edition])
           end
         end
-      end
-      
-      for i = 0,1 do
-        for x = 4+i,14+i,5 do
-          for j = 1,3+i do
-            g:led(x,j,zilch_leds[i == 0 and 3 or 4][util.round(x/5)][j] == 1 and led_maps["zilchmo_on"][edition] or led_maps["zilchmo_off"][edition])
-          end
-        end
-      end
 
-      for x = 3,13,5 do
-        for j = 1,2 do
-          g:led(x,j,zilch_leds[2][util.round(x/5)][j] == 1 and led_maps["zilchmo_on"][edition] or led_maps["zilchmo_off"][edition])
-        end
-      end
-      
-      for i = 1,3 do
-        local target = grid_pat[i]
-        if target.rec == 1 then
-          g:led(2+(5*(i-1)),1,(9*target.led))
-        elseif (target.quantize == 0 and target.play == 1) or (target.quantize == 1 and target.tightened_start == 1) then
-          if target.overdub == 0 then
-            g:led(2+(5*(i-1)),1,9)
-          else
-            g:led(2+(5*(i-1)),1,15)
-          end
-        elseif target.count > 0 then
-          g:led(2+(5*(i-1)),1,5)
-        else
-          g:led(2+(5*(i-1)),1,3)
-        end
-      end
-      
-      for i = 1,3 do
-        local a_p; -- this will index the arc encoder recorders
-        if arc_param[i] == 1 or arc_param[i] == 2 or arc_param[i] == 3 then
-          a_p = 1
-        else
-          a_p = arc_param[i] - 2
-        end
-        if arc_pat[i][a_p].rec == 1 then
-          g:led(16,5-i,led_maps["arc_rec_rec"][edition])
-        elseif arc_pat[i][a_p].play == 1 then
-          g:led(16,5-i,led_maps["arc_rec_play"][edition])
-        elseif arc_pat[i][a_p].count > 0 then
-          g:led(16,5-i,led_maps["arc_rec_pause"][edition])
-        else
-          g:led(16,5-i,led_maps["arc_rec_off"][edition])
-        end
-      end
-      
-      if a.device ~= nil then
-        for i = 1,3 do
-          for j = 5,15,5 do
-            g:led(j,8,arc_param[j/5] == 1 and 5 or 0)
-            g:led(j,7,arc_param[j/5] == 2 and 5 or 0)
-            g:led(j,6,arc_param[j/5] == 3 and 5 or 0)
-            if arc_param[j/5] == 4 then
-              for k = 8,6,-1 do
-                g:led(j,k,led_maps["arc_param_show"][edition])
-              end
-            elseif arc_param[j/5] == 5 then
-              g:led(j,8,led_maps["arc_param_show"][edition])
-              g:led(j,7,led_maps["arc_param_show"][edition])
-            elseif arc_param[j/5] == 6 then
-              g:led(j,7,led_maps["arc_param_show"][edition])
-              g:led(j,6,led_maps["arc_param_show"][edition])
-            end
-          end
-        end
-      end
-      
-      for i = 1,3 do
-        if bank[i].focus_hold == false then
-          g:led(selected[i].x, selected[i].y, led_maps["square_selected"][edition])
-          if i == nil then print("2339") end
-          if bank[i].id == nil then print("2340", i) end
-          if bank[i][bank[i].id].pause == nil then print("2341") end
-          if bank[i][bank[i].id].pause == true then
-            g:led(3+(5*(i-1)),1,led_maps["pad_pause"][edition])
-            g:led(3+(5*(i-1)),2,led_maps["pad_pause"][edition])
-          else
-            -- g:led(3+(5*(i-1)),1,led_maps["pad_play"][edition])
-            -- g:led(3+(5*(i-1)),2,led_maps["pad_play"][edition])
-            g:led(3+(5*(i-1)),1,zilch_leds[2][i][1] == 1 and led_maps["zilchmo_on"][edition] or led_maps["zilchmo_off"][edition])
-            g:led(3+(5*(i-1)),2,zilch_leds[2][i][2] == 1 and led_maps["zilchmo_on"][edition] or led_maps["zilchmo_off"][edition])
-          end
-        else
-          local focus_x = (math.ceil(bank[i].focus_pad/4)+(5*(i-1)))
-          local focus_y = 8-((bank[i].focus_pad-1)%4)
-          g:led(selected[i].x, selected[i].y, led_maps["square_dim"][edition])
-          g:led(focus_x, focus_y, led_maps["square_selected"][edition])
-          if bank[i][bank[i].focus_pad].pause == true then
-            g:led(3+(5*(i-1)),1,led_maps["square_selected"][edition])
-            g:led(3+(5*(i-1)),2,led_maps["square_selected"][edition])
-          else
-            g:led(3+(5*(i-1)),1,led_maps["square_off"][edition])
-            g:led(3+(5*(i-1)),2,led_maps["square_off"][edition])
-          end
-        end
-      end
-      
-      for i = 1,3 do
-        if bank[i].focus_hold then
-          g:led(4+(5*(i-1)),4,(10*bank[i][bank[i].focus_pad].crow_pad_execute)+5)
-        end
-        -- if bank[i].focus_hold == true then
-        --   g:led(5*i,5,(10*bank[i][bank[i].focus_pad].crow_pad_execute)+5)
-        -- else
-        --   local alt = bank[i].alt_lock and 1 or 0
-        --   g:led(5*i,5,15*alt)
-        -- end
-        local alt = bank[i].alt_lock and 1 or 0
-        g:led(5*i,5,15*alt)
-      end
-      
-      for i,e in pairs(lit) do
-        g:led(e.x, e.y,led_maps["zilchmo_on"][edition])
-      end
-      
-      g:led(16,8,(grid.alt and led_maps["alt_on"][edition] or led_maps["alt_off"][edition]))
-      
-      for i = 1,3 do
-        
-        local focused = bank[i].focus_hold == false and bank[i][bank[i].id] or bank[i][bank[i].focus_pad]
+        local shifted_x = (selected[delay_grid.bank].x - (5*(delay_grid.bank-1)))+9
+        local shifted_y = selected[delay_grid.bank].y - 2
+        g:led(shifted_x, shifted_y, led_maps["square_selected"][edition])
 
-        g:led(1 + (5*(i-1)), math.abs(focused.clip-5),led_maps["clip"][edition])
-        g:led(2 + (5*(i-1)), math.abs(focused.mode-5),led_maps["mode"][edition])
-        g:led(1+(5*(i-1)),1,bank[i].focus_hold == false and led_maps["off"][edition] or led_maps["focus_on"][edition])
-        if focused.loop == false then
-          g:led(3+(5*(i-1)),4,led_maps["loop_off"][edition])
-        elseif focused.loop == true then
-          g:led(3+(5*(i-1)),4,led_maps["loop_on"][edition])
+        for i = 4,6 do
+          g:led(14,i,delay_grid.bank == 7-i and led_maps["selected_bank"][edition] or led_maps["unselected_bank"][edition])
         end
-        if not arp[i].enabled then
-          g:led(3+(5*(i-1)),3,led_maps["off"][edition])
-        else
-          if arp[i].playing and arp[i].hold then
-            g:led(3+(5*(i-1)),3,led_maps["arp_play"][edition])
-          elseif arp[i].hold then
-            g:led(3+(5*(i-1)),3,led_maps["arp_pause"][edition])
-          else
-            g:led(3+(5*(i-1)),3,led_maps["arp_on"][edition])
+
+        -- send levels
+
+        local send_to_led = {{},{}}
+        local send_level = {bank[delay_grid.bank][bank[delay_grid.bank].id].left_delay_level, bank[delay_grid.bank][bank[delay_grid.bank].id].right_delay_level}
+        for i = 1,2 do
+          if send_level[i] <= 0.125 then
+            send_to_led[i] = 0
+          elseif send_level[i] <= 0.375 then
+            send_to_led[i] = 1
+          elseif send_level[i] <= 0.625 then
+            send_to_led[i] = 2
+          elseif send_level[i] <= 0.875 then
+            send_to_led[i] = 3
+          elseif send_level[i] <= 1.0 then
+            send_to_led[i] = 4
           end
         end
 
-      end
-      
-      if rec[rec.focus].clear == 0 then
-        g:led(16,8-rec.focus,rec[rec.focus].state == 1 and led_maps["live_rec"][edition] or led_maps["live_pause"][edition])
-      elseif rec[rec.focus].clear == 1 then
-        g:led(16,8-rec.focus,led_maps["live_empty"][edition])
-      end
-    
-    elseif grid_page == 1 then
-      
-      -- if we're on page 2...
-      
-      for i = 1,3 do
-
-        for j = step_seq[i].start_point,step_seq[i].end_point do
-          local xval = j < 9 and (i*5)-2 or (i*5)-1
-          local yval = j < 9 and 9 or 17
-
-          g:led(xval,yval-j,led_maps["step_no_data"][edition])
-
-          if grid.loop_mod == 1 then
-            g:led(xval,yval-step_seq[i].start_point,led_maps["step_loops"][edition])
-            g:led(xval,yval-step_seq[i].end_point,led_maps["step_loops"][edition])
-          end
-
-        end
-
-        for j = 1,16 do
-          if step_seq[i][j].assigned_to ~= 0 then
-            local xval = j < 9 and (i*5)-2 or (i*5)-1
-            local yval = j < 9 and 9 or 17
-            g:led(xval,yval-j,led_maps["step_yes_data"][edition])
-          end
-        end
-
-        if step_seq[i].current_step < 9 then
-          g:led((i*5)-2,9-step_seq[i].current_step,led_maps["step_current"][edition])
-        elseif step_seq[i].current_step >=9 then
-          g:led((i*5)-1,9-(step_seq[i].current_step-8),led_maps["step_current"][edition])
-        end
-
-        if step_seq[i].held < 9 then
-          g:led((i*5)-2,9-step_seq[i].held,led_maps["step_held"][edition])
-        elseif step_seq[i].held >= 9 then
-          g:led((i*5)-1,9-(step_seq[i].held-8),led_maps["step_held"][edition])
-        end
-
-        g:led((i*5)-3, 9-step_seq[i].meta_duration,led_maps["meta_duration"][edition])
-        g:led((i*5)-3, 9-step_seq[i].meta_step,led_maps["meta_step_hi"][edition])
-
-        if step_seq[i].held == 0 then
-          g:led((i*5), 9-step_seq[i][step_seq[i].current_step].meta_meta_duration,led_maps["meta_duration"][edition])
-          g:led((i*5), 9-step_seq[i].meta_meta_step,led_maps["meta_step_hi"][edition])
-        else
-          g:led((i*5), 9-step_seq[i].meta_meta_step,led_maps["meta_step_lo"][edition])
-          g:led((i*5), 9-step_seq[i][step_seq[i].held].meta_meta_duration,led_maps["meta_duration"][edition])
-        end
-        if step_seq[i].held == 0 then
-          g:led(16,8-i,edition == 3 and (15*step_seq[i].active) or ((step_seq[i].active*6)+2))
-        else
-          g:led(16,8-i,step_seq[i][step_seq[i].held].loop_pattern*4)
-        end
-
-      end
-      
-      for i = 1,11,5 do
-        for j = 1,8 do
-          local current = math.floor(i/5)+1
-          local show = step_seq[current].held == 0 and pattern_saver[current].load_slot or step_seq[current][step_seq[current].held].assigned_to
-          g:led(i,j,edition == 3 and (15*pattern_saver[current].saved[9-j]) or ((5*pattern_saver[current].saved[9-j])+2))
-          g:led(i,j,j == (9 - show) and 15 or (edition == 3 and (15*pattern_saver[current].saved[9-j]) or ((5*pattern_saver[current].saved[9-j])+2)))
-        end
-      end
-      
-      g:led(16,8,grid.alt and led_maps["alt_on"][edition] or led_maps["alt_off"][edition])
-      g:led(16,2,grid.loop_mod == 1 and led_maps["loop_mod_hi"][edition] or led_maps["loop_mod_lo"][edition])
-    
-    elseif grid_page == 2 then
-      -- delay page!
-      for i = 1,8 do
-        local check = {i+8, i}
-        for j = 1,2 do
-          g:led(i,j,delay[2].selected_bundle == check[j] and 15 or (delay_bundle[2][check[j]].saved == true and led_maps["bundle_saved"][edition] or led_maps["bundle_empty"][edition]))
-          g:led(i,j+6,delay[1].selected_bundle == check[j] and 15 or (delay_bundle[1][check[j]].saved == true and led_maps["bundle_saved"][edition] or led_maps["bundle_empty"][edition]))
-        end
-      end
-
-      -- delay time modifiers
-      local time_to_led = {{},{},{},{}}
-      local time = {delay[1].modifier, delay[2].modifier}
-      for i = 1,2 do
-        time_to_led[i] = 0
-        time_to_led[i+2] = 0
-        if time[i] == 0.5 then
-          time_to_led[i+2] = led_maps["time_to_led.5"][edition]
-        elseif time[i] == 0.25 then
-          time_to_led[i+2] = led_maps["time_to_led.25"][edition]
-        elseif time[i] == 0.125 then
-          time_to_led[i+2] = led_maps["time_to_led.125"][edition]
-        elseif time[i] == 2 then
-          time_to_led[i] = led_maps["time_to_led2"][edition]
-        elseif time[i] == 4 then
-          time_to_led[i] = led_maps["time_to_led4"][edition]
-        elseif time[i] == 8 then
-          time_to_led[i] = led_maps["time_to_led8"][edition]
-        elseif time[i] == 16 then
-          time_to_led[i] = led_maps["time_to_led16"][edition]
-        end
-      end
-      g:led(1,3,time_to_led[2])
-      g:led(2,3,time_to_led[4])
-      g:led(1,6,time_to_led[1])
-      g:led(2,6,time_to_led[3])
-      g:led(3,3,delay[2].reverse and led_maps["reverse_on"][edition] or led_maps["reverse_off"][edition])
-      g:led(3,6,delay[1].reverse and led_maps["reverse_on"][edition] or led_maps["reverse_off"][edition])
-
-      rate_to_led = {{},{},{},{}}
-      local rate = {params:get("delay L: rate"), params:get("delay R: rate")}
-      for i = 1,2 do
-        rate_to_led[i] = 0
-        rate_to_led[i+2] = 0
-        for j = 1,24 do
-          if math.modf(rate[i]) >= j then
-            rate_to_led[i] = math.modf(util.linlin(0,24,3,15,j))
-          end
-        end
-        for j = 0.25,1,0.05 do
-          if rate[i] >= j then
-            rate_to_led[i+2] = math.modf(util.linlin(0.25,1,15,0,j))
-          end
-        end
-        if rate[i] == 1 then
-          rate_to_led[i+2] = 3
-        end
-      end
-      g:led(1,4,rate_to_led[2])
-      g:led(2,4,rate_to_led[4])
-      g:led(3,4,delay[2].wobble_hold and led_maps["wobble_on"][edition] or led_maps["wobble_off"][edition])
-      g:led(1,5,rate_to_led[1])
-      g:led(2,5,rate_to_led[3])
-      g:led(3,5,delay[1].wobble_hold and led_maps["wobble_on"][edition] or led_maps["wobble_off"][edition])
-      
-      -- delay levels
-      local level_to_led = {{},{}}
-      local delay_level = {params:get("delay L: global level"), params:get("delay R: global level")}
-      for i = 1,2 do
-        if delay_level[i] <= 0.125 then
-          level_to_led[i] = 0
-        elseif delay_level[i] <= 0.375 then
-          level_to_led[i] = 1
-        elseif delay_level[i] <= 0.625 then
-          level_to_led[i] = 2
-        elseif delay_level[i] <= 0.875 then
-          level_to_led[i] = 3
-        elseif delay_level[i] <= 1 then
-          level_to_led[i] = 4
-        end
-      end
-      for i = 8,4,-1 do
-        g:led(i,6,led_maps["level_lo"][edition])
-        g:led(i,3,led_maps["level_lo"][edition])
-      end
-      for i = 1,2 do
-        if not delay[i].level_mute then
-          for j = 8,4+(4-level_to_led[i]),-1 do
-            g:led(j,i==1 and 6 or 3,led_maps["level_hi"][edition])
-          end
-        else
-          if params:get(i == 1 and "delay L: global level" or "delay R: global level") == 0 then
-            for j = 8,4,-1 do
-              g:led(j,i==1 and 6 or 3,led_maps["level_hi"][edition])
-            end
-          end
-        end
-      end
-
-      -- feedback levels
-      local feed_to_led = {{},{}}
-      local feedback_level = {params:get("delay L: feedback"), params:get("delay R: feedback")}
-      for i = 1,2 do
-        if feedback_level[i] <= 12.5 then
-          feed_to_led[i] = 0
-        elseif feedback_level[i] <= 37.5 then
-          feed_to_led[i] = 1
-        elseif feedback_level[i] <= 62.5 then
-          feed_to_led[i] = 2
-        elseif feedback_level[i] <= 87.5 then
-          feed_to_led[i] = 3
-        elseif feedback_level[i] <= 100 then
-          feed_to_led[i] = 4
-        end
-      end
-      for i = 8,4,-1 do
-        g:led(i,5,led_maps["level_lo"][edition])
-        g:led(i,4,led_maps["level_lo"][edition])
-      end
-      for i = 1,2 do
-        if not delay[i].feedback_mute then
-          for j = 8,4+(4-feed_to_led[i]),-1 do
-            g:led(j,i==1 and 5 or 4,led_maps["level_hi"][edition])
-          end
-        else
-          if params:get(i == 1 and "delay L: feedback" or "delay R: feedback") == 0 then
-            for j = 8,4,-1 do
-              g:led(j,i==1 and 5 or 4,led_maps["level_hi"][edition])
-            end
-          end
-        end
-      end
-
-      for k = 10,13 do
-        for i = 6,3,-1 do
-          g:led(k,i,led_maps["square_off"][edition])
-        end
-      end
-
-      local shifted_x = (selected[delay_grid.bank].x - (5*(delay_grid.bank-1)))+9
-      local shifted_y = selected[delay_grid.bank].y - 2
-      g:led(shifted_x, shifted_y, led_maps["square_selected"][edition])
-
-      for i = 4,6 do
-        g:led(14,i,delay_grid.bank == 7-i and led_maps["selected_bank"][edition] or led_maps["unselected_bank"][edition])
-      end
-
-      -- send levels
-
-      local send_to_led = {{},{}}
-      local send_level = {bank[delay_grid.bank][bank[delay_grid.bank].id].left_delay_level, bank[delay_grid.bank][bank[delay_grid.bank].id].right_delay_level}
-      for i = 1,2 do
-        if send_level[i] <= 0.125 then
-          send_to_led[i] = 0
-        elseif send_level[i] <= 0.375 then
-          send_to_led[i] = 1
-        elseif send_level[i] <= 0.625 then
-          send_to_led[i] = 2
-        elseif send_level[i] <= 0.875 then
-          send_to_led[i] = 3
-        elseif send_level[i] <= 1.0 then
-          send_to_led[i] = 4
-        end
-      end
-
-      for i = 1,2 do
-        if not delay[i].send_mute then
-          for j = 14,10+(4-send_to_led[i]),-1 do
-            g:led(j,i==1 and 8 or 1,led_maps["level_hi"][edition])
-          end
-        else
-          if (i == 1 and bank[delay_grid.bank][bank[delay_grid.bank].id].left_delay_level or bank[delay_grid.bank][bank[delay_grid.bank].id].right_delay_level) == 0 then
-            for j = 14,10,-1 do
+        for i = 1,2 do
+          if not delay[i].send_mute then
+            for j = 14,10+(4-send_to_led[i]),-1 do
               g:led(j,i==1 and 8 or 1,led_maps["level_hi"][edition])
             end
+          else
+            if (i == 1 and bank[delay_grid.bank][bank[delay_grid.bank].id].left_delay_level or bank[delay_grid.bank][bank[delay_grid.bank].id].right_delay_level) == 0 then
+              for j = 14,10,-1 do
+                g:led(j,i==1 and 8 or 1,led_maps["level_hi"][edition])
+              end
+            end
           end
         end
-      end
 
-      --arp button
-      if not arp[delay_grid.bank].enabled then
-        g:led(12,2,led_maps["off"][edition])
-      else
-        if arp[delay_grid.bank].playing and arp[delay_grid.bank].hold then
-          g:led(12,2,led_maps["arp_play"][edition])
-        elseif arp[delay_grid.bank].hold then
-          g:led(12,2,led_maps["arp_pause"][edition])
+        --arp button
+        if not arp[delay_grid.bank].enabled then
+          g:led(12,2,led_maps["off"][edition])
         else
-          g:led(12,2,led_maps["arp_on"][edition])
+          if arp[delay_grid.bank].playing and arp[delay_grid.bank].hold then
+            g:led(12,2,led_maps["arp_play"][edition])
+          elseif arp[delay_grid.bank].hold then
+            g:led(12,2,led_maps["arp_pause"][edition])
+          else
+            g:led(12,2,led_maps["arp_on"][edition])
+          end
         end
+
+        if bank[delay_grid.bank][bank[delay_grid.bank].id].loop == false then
+          g:led(13,2,led_maps["loop_off"][edition])
+        else
+          g:led(13,2,led_maps["loop_on"][edition])
+        end
+
+
+
+        g:led(16,8,(grid.alt and led_maps["alt_on"][edition] or led_maps["alt_off"][edition]))
+
+        for j = 1,4 do
+          g:led(15,math.abs(j-7),zilch_leds[4][delay_grid.bank][j] == 1 and led_maps["zilchmo_on"][edition] or led_maps["zilchmo_off"][edition])
+        end
+
       end
 
-      if bank[delay_grid.bank][bank[delay_grid.bank].id].loop == false then
-        g:led(13,2,led_maps["loop_off"][edition])
-      else
-        g:led(13,2,led_maps["loop_on"][edition])
+      local page_led = {[0] = 0, [1] = 7, [2] = 15}
+      if grid_page ~= nil then
+        g:led(16,1,led_maps["page_led"][grid_page+1][edition])
       end
+      
+      g:refresh()
+    elseif params:string("grid_size") == "64" then
+      g:all(0)
+      local edition = params:get("LED_style")
 
+      g:led(8,1,led_maps["square_off"][edition])
+      
+      if grid_page_64 == 0 then
 
+        for x = 1,3 do
+          g:led(x,1,x == bank_64 and 12 or 4)
+        end
+        
+        --main playable grid
+        for x = 1,4 do
+          for y = 4,7 do
+            g:led(x,y,led_maps["square_off"][edition])
+          end
+        end
 
-      g:led(16,8,(grid.alt and led_maps["alt_on"][edition] or led_maps["alt_off"][edition]))
+        --zilchmos
+        for x = 5,8 do
+          g:led(x,8,zilch_leds[4][bank_64][x-4] == 1 and led_maps["zilchmo_on"][edition] or led_maps["zilchmo_off"][edition])
+        end
 
-      for j = 1,4 do
-        g:led(15,math.abs(j-7),zilch_leds[4][delay_grid.bank][j] == 1 and led_maps["zilchmo_on"][edition] or led_maps["zilchmo_off"][edition])
+        for x = 6,8 do
+          g:led(x,7,zilch_leds[3][bank_64][x-5] == 1 and led_maps["zilchmo_on"][edition] or led_maps["zilchmo_off"][edition])
+        end
+
+        --pattern rec
+        local target = grid_pat[bank_64]
+        if target.rec == 1 then
+          g:led(8,5,(9*target.led))
+        elseif (target.quantize == 0 and target.play == 1) or (target.quantize == 1 and target.tightened_start == 1) then
+          if target.overdub == 0 then
+            g:led(8,5,9)
+          else
+            g:led(8,5,15)
+          end
+        elseif target.count > 0 then
+          g:led(8,5,5)
+        else
+          g:led(8,5,3)
+        end
+        
+        --arc rec
+        -- local a_p; -- this will index the arc encoder recorders
+        -- if arc_param[bank_64] == 1 or arc_param[bank_64] == 2 or arc_param[bank_64] == 3 then
+        --   a_p = 1
+        -- else
+        --   a_p = arc_param[bank_64] - 2
+        -- end
+        -- if arc_pat[bank_64][a_p].rec == 1 then
+        --   g:led(7,8,led_maps["arc_rec_rec"][edition])
+        -- elseif arc_pat[bank_64][a_p].play == 1 then
+        --   g:led(7,8,led_maps["arc_rec_play"][edition])
+        -- elseif arc_pat[bank_64][a_p].count > 0 then
+        --   g:led(7,8,led_maps["arc_rec_pause"][edition])
+        -- else
+        --   g:led(7,8,led_maps["arc_rec_off"][edition])
+        -- end
+        
+        --arc control
+        if a.device ~= nil then
+          g:led(1,8,arc_param[bank_64] == 1 and 5 or 0)
+          g:led(2,8,arc_param[bank_64] == 1 and 5 or 0)
+          g:led(3,8,arc_param[bank_64] == 1 and 5 or 0)
+          if arc_param[bank_64] == 4 then
+            for x = 1,3 do
+              g:led(x,8,led_maps["arc_param_show"][edition])
+            end
+          elseif arc_param[j/5] == 5 then
+            g:led(1,8,led_maps["arc_param_show"][edition])
+            g:led(2,8,led_maps["arc_param_show"][edition])
+          elseif arc_param[j/5] == 6 then
+            g:led(2,8,led_maps["arc_param_show"][edition])
+            g:led(3,8,led_maps["arc_param_show"][edition])
+          end
+        end
+        
+        --4x4 pads
+        if bank[bank_64].focus_hold == false then
+          local x_64 = (9-selected[bank_64].y)
+          local y_64 = selected[bank_64].x - (5*(bank_64-1))
+          g:led(x_64, y_64+3, led_maps["square_selected"][edition])
+          if bank[bank_64][bank[bank_64].id].pause == true then
+            g:led(8,6,led_maps["pad_pause"][edition])
+            g:led(7,6,led_maps["pad_pause"][edition])
+          else
+            g:led(7,6,zilch_leds[2][bank_64][1] == 1 and led_maps["zilchmo_on"][edition] or led_maps["zilchmo_off"][edition])
+            g:led(8,6,zilch_leds[2][bank_64][2] == 1 and led_maps["zilchmo_on"][edition] or led_maps["zilchmo_off"][edition])
+          end
+        else
+          local x_64 = (9-selected[bank_64].y)
+          local y_64 = selected[bank_64].x - (5*(bank_64-1))
+          local focus_x_64 = bank[bank_64].focus_pad - (4*(math.ceil(bank[bank_64].focus_pad/4)-1))
+          local focus_y_64 = math.ceil(bank[bank_64].focus_pad/4)
+          g:led(x_64, y_64+3, led_maps["square_dim"][edition])
+          g:led(focus_x_64, focus_y_64+3, led_maps["square_selected"][edition])
+          if bank[bank_64][bank[bank_64].focus_pad].pause == true then
+            g:led(8,6,led_maps["square_selected"][edition])
+            g:led(7,6,led_maps["square_selected"][edition])
+          else
+            g:led(7,6,led_maps["square_off"][edition])
+            g:led(8,6,led_maps["square_off"][edition])
+          end
+        end
+        
+        -- crow pad execute
+        if bank[bank_64].focus_hold then
+          g:led(5,7,(10*bank[bank_64][bank[bank_64].focus_pad].crow_pad_execute)+5)
+        end
+        local alt = bank[bank_64].alt_lock and 1 or 0
+        g:led(4,8,15*alt)
+        
+        -- for i,e in pairs(lit) do
+        --   g:led(e.x, e.y,led_maps["zilchmo_on"][edition])
+        -- end
+        
+        --alt
+        g:led(1,8,(grid.alt and led_maps["alt_on"][edition] or led_maps["alt_off"][edition]))
+          
+        local focused = bank[bank_64].focus_hold == false and bank[bank_64][bank[bank_64].id] or bank[bank_64][bank[bank_64].focus_pad]
+        --clips + stuff
+        g:led(focused.clip+4,4,led_maps["clip"][edition])
+        g:led(focused.mode+4,5,led_maps["mode"][edition])
+        g:led(8,4,bank[bank_64].focus_hold == false and led_maps["off"][edition] or led_maps["focus_on"][edition])
+        if focused.loop == false then
+          g:led(5,6,led_maps["loop_off"][edition])
+        elseif focused.loop == true then
+          g:led(5,6,led_maps["loop_on"][edition])
+        end
+        if not arp[bank_64].enabled then
+          g:led(6,6,led_maps["off"][edition])
+        else
+          if arp[bank_64].playing and arp[bank_64].hold then
+            g:led(6,6,led_maps["arp_play"][edition])
+          elseif arp[bank_64].hold then
+            g:led(6,6,led_maps["arp_pause"][edition])
+          else
+            g:led(6,6,led_maps["arp_on"][edition])
+          end
+        end
+        
+        -- Live buffers
+        if rec[rec.focus].clear == 0 then
+          g:led(rec.focus,2,rec[rec.focus].state == 1 and led_maps["live_rec"][edition] or led_maps["live_pause"][edition])
+        elseif rec[rec.focus].clear == 1 then
+          g:led(rec.focus,2,led_maps["live_empty"][edition])
+        end
+      
+      elseif grid_page_64 == 1 then
+
+        -- delay page!
+        for i = 1,5 do
+          g:led(8,i+2,delay[2].selected_bundle == i and 15 or (delay_bundle[2][i].saved == true and led_maps["bundle_saved"][edition] or 0))
+          g:led(1,i+2,delay[1].selected_bundle == i and 15 or (delay_bundle[1][i].saved == true and led_maps["bundle_saved"][edition] or 0))
+        end
+
+        for i = 1,3 do
+          g:led(2,i,bank[i][bank[i].id].left_delay_level > 0 and led_maps["64_bank_send"][edition] or 0)
+          g:led(7,i,bank[i][bank[i].id].right_delay_level > 0 and led_maps["64_bank_send"][edition] or 0)
+        end
+
+        g:led(2,4,params:get("delay L: external input") > 0 and led_maps["64_bank_send"][edition] or 0)
+        g:led(7,4,params:get("delay R: external input") > 0 and led_maps["64_bank_send"][edition] or 0)
+
+        -- delay time modifiers
+        local time_to_led = {{},{},{},{}}
+        local time = {delay[1].modifier, delay[2].modifier}
+        for i = 1,2 do
+          time_to_led[i] = 0
+          time_to_led[i+2] = 0
+          if time[i] == 0.5 then
+            time_to_led[i+2] = led_maps["time_to_led.5"][edition]
+          elseif time[i] == 0.25 then
+            time_to_led[i+2] = led_maps["time_to_led.25"][edition]
+          elseif time[i] == 0.125 then
+            time_to_led[i+2] = led_maps["time_to_led.125"][edition]
+          elseif time[i] == 2 then
+            time_to_led[i] = led_maps["time_to_led2"][edition]
+          elseif time[i] == 4 then
+            time_to_led[i] = led_maps["time_to_led4"][edition]
+          elseif time[i] == 8 then
+            time_to_led[i] = led_maps["time_to_led8"][edition]
+          elseif time[i] == 16 then
+            time_to_led[i] = led_maps["time_to_led16"][edition]
+          end
+        end
+        g:led(6,1,time_to_led[2])
+        g:led(6,2,time_to_led[4])
+        g:led(3,1,time_to_led[1])
+        g:led(3,2,time_to_led[3])
+        g:led(6,3,delay[2].reverse and led_maps["reverse_on"][edition] or led_maps["reverse_off"][edition])
+        g:led(3,3,delay[1].reverse and led_maps["reverse_on"][edition] or led_maps["reverse_off"][edition])
+
+        rate_to_led = {{},{},{},{}}
+        local rate = {params:get("delay L: rate"), params:get("delay R: rate")}
+        for i = 1,2 do
+          rate_to_led[i] = 0
+          rate_to_led[i+2] = 0
+          for j = 1,24 do
+            if math.modf(rate[i]) >= j then
+              rate_to_led[i] = math.modf(util.linlin(0,24,3,15,j))
+            end
+          end
+          for j = 0.25,1,0.05 do
+            if rate[i] >= j then
+              rate_to_led[i+2] = math.modf(util.linlin(0.25,1,15,0,j))
+            end
+          end
+          if rate[i] == 1 then
+            rate_to_led[i+2] = 3
+          end
+        end
+        g:led(5,1,rate_to_led[2])
+        g:led(5,2,rate_to_led[4])
+        g:led(5,3,delay[2].wobble_hold and led_maps["wobble_on"][edition] or led_maps["wobble_off"][edition])
+        g:led(4,1,rate_to_led[1])
+        g:led(4,2,rate_to_led[3])
+        g:led(4,3,delay[1].wobble_hold and led_maps["wobble_on"][edition] or led_maps["wobble_off"][edition])
+        
+        -- delay levels
+        local level_to_led = {{},{}}
+        local delay_level = {params:get("delay L: global level"), params:get("delay R: global level")}
+        for i = 1,2 do
+          if delay_level[i] <= 0.125 then
+            level_to_led[i] = 0
+          elseif delay_level[i] <= 0.375 then
+            level_to_led[i] = 1
+          elseif delay_level[i] <= 0.625 then
+            level_to_led[i] = 2
+          elseif delay_level[i] <= 0.875 then
+            level_to_led[i] = 3
+          elseif delay_level[i] <= 1 then
+            level_to_led[i] = 4
+          end
+        end
+        for i = 8,4,-1 do
+          g:led(3,i,led_maps["level_lo"][edition])
+          g:led(6,i,led_maps["level_lo"][edition])
+        end
+        for i = 1,2 do
+          if not delay[i].level_mute then
+            for j = 8,4+(4-level_to_led[i]),-1 do
+              g:led(i==1 and 3 or 6,j,led_maps["level_hi"][edition])
+            end
+          else
+            if params:get(i == 1 and "delay L: global level" or "delay R: global level") == 0 then
+              for j = 8,4,-1 do
+                g:led(i==1 and 3 or 6,j,led_maps["level_hi"][edition])
+              end
+            end
+          end
+        end
+
+        -- feedback levels
+        local feed_to_led = {{},{}}
+        local feedback_level = {params:get("delay L: feedback"), params:get("delay R: feedback")}
+        for i = 1,2 do
+          if feedback_level[i] <= 12.5 then
+            feed_to_led[i] = 0
+          elseif feedback_level[i] <= 37.5 then
+            feed_to_led[i] = 1
+          elseif feedback_level[i] <= 62.5 then
+            feed_to_led[i] = 2
+          elseif feedback_level[i] <= 87.5 then
+            feed_to_led[i] = 3
+          elseif feedback_level[i] <= 100 then
+            feed_to_led[i] = 4
+          end
+        end
+        for i = 8,4,-1 do
+          g:led(4,i,led_maps["level_lo"][edition])
+          g:led(5,i,led_maps["level_lo"][edition])
+        end
+        for i = 1,2 do
+          if not delay[i].feedback_mute then
+            for j = 8,4+(4-feed_to_led[i]),-1 do
+              g:led(i==1 and 4 or 5,j,led_maps["level_hi"][edition])
+            end
+          else
+            if params:get(i == 1 and "delay L: feedback" or "delay R: feedback") == 0 then
+              for j = 8,4,-1 do
+                g:led(i==1 and 4 or 5,j,led_maps["level_hi"][edition])
+              end
+            end
+          end
+        end
+
       end
-
+      
+      g:refresh()
     end
-
-    local page_led = {[0] = 0, [1] = 7, [2] = 15}
-    if grid_page ~= nil then
-      g:led(16,1,led_maps["page_led"][grid_page+1][edition])
-    end
-    
-    g:refresh()
   end
 end
 --/GRID
@@ -4471,6 +4861,7 @@ function persistent_state_save()
   for i = 1,3 do
     io.write("bank_"..i.."_midi_zilchmo_enabled: "..params:get("bank_"..i.."_midi_zilchmo_enabled").."\n")
   end
+  io.write("grid_size: "..params:get("grid_size").."\n")
   io.close(file)
 end
 
@@ -4678,6 +5069,8 @@ function named_loadstate(path)
     -- persistent_state_restore()
     if tab.load(_path.data .. "cheat_codes_2/collection-"..collection.."/rec/rec[rec.focus].data") ~= nil then
       rec = tab.load(_path.data .. "cheat_codes_2/collection-"..collection.."/rec/rec[rec.focus].data")
+      if rec.stopped == nil then rec.stopped = false end
+      if rec.play_segment == nil then rec.play_segment = rec.focus end
       softcut.loop_start(1,rec[rec.focus].start_point)
       softcut.loop_end(1,rec[rec.focus].end_point-0.01)
     end

--- a/lib/arc_actions.lua
+++ b/lib/arc_actions.lua
@@ -98,8 +98,7 @@ function aa.move_window(target, delta)
   local duration = target.mode == 1 and 8 or clip[target.clip].sample_length
   local current_difference = (target.end_point - target.start_point)
   local s_p = target.mode == 1 and live[target.clip].min or clip[target.clip].min
-  local current_clip = duration*(target.clip-1)
-  local reasonable_max = target.mode == 1 and 9 or clip[target.clip].max
+  local reasonable_max = target.mode == 1 and live[target.clip].max or clip[target.clip].max
   local adjusted_delta = force and (duration > 15 and (delta/25) or (delta/100)) or (delta/300)
   if target.start_point + current_difference <= reasonable_max then
     target.start_point = util.clamp(target.start_point + adjusted_delta, s_p, reasonable_max)

--- a/lib/grid_actions.lua
+++ b/lib/grid_actions.lua
@@ -34,913 +34,1321 @@ function grid_actions.init(x,y,z)
   
   if osc_communication == true then osc_communication = false end
   
-  if grid_page == 0 then
-    
-    for i = 1,3 do
-      if grid.alt then
-        if x == 1+(5*(i-1)) and y == 1 and z == 1 then
-          bank[i].focus_hold = not bank[i].focus_hold
-          mc.mft_redraw(bank[i][bank[i].focus_hold and bank[i].focus_pad or bank[i].id],"all")
+  if params:string("grid_size") == "128" then
+
+    if grid_page == 0 then
+      
+      for i = 1,3 do
+        if grid.alt then
+          if x == 1+(5*(i-1)) and y == 1 and z == 1 then
+            bank[i].focus_hold = not bank[i].focus_hold
+            mc.mft_redraw(bank[i][bank[i].focus_hold and bank[i].focus_pad or bank[i].id],"all")
+          end
         end
       end
-    end
-    
-    for i = 1,3 do
-      if z == 1 and x > 0 + (5*(i-1)) and x <= 4 + (5*(i-1)) and y >=5 then
-        if bank[i].focus_hold == false then
-          if not grid.alt then
-            selected[i].x = x
-            selected[i].y = y
-            selected[i].id = (math.abs(y-9)+((x-1)*4))-(20*(i-1))
-            bank[i].id = selected[i].id
-            which_bank = i
-            if menu == 11 then
-              help_menu = "banks"
-            end
-            pad_clipboard = nil
-            if bank[i].quantize_press == 0 then
-              if arp[i].enabled and grid_pat[i].rec == 0 and not arp[i].pause then
-                if arp[i].down == 0 and params:string("arp_"..i.."_hold_style") == "last pressed" then
-                  for j = #arp[i].notes,1,-1 do
-                    table.remove(arp[i].notes,j)
+      
+      for i = 1,3 do
+        if z == 1 and x > 0 + (5*(i-1)) and x <= 4 + (5*(i-1)) and y >=5 then
+          if bank[i].focus_hold == false then
+            if not grid.alt then
+              selected[i].x = x
+              selected[i].y = y
+              selected[i].id = (math.abs(y-9)+((x-1)*4))-(20*(i-1))
+              bank[i].id = selected[i].id
+              which_bank = i
+              if menu == 11 then
+                help_menu = "banks"
+              end
+              pad_clipboard = nil
+              if bank[i].quantize_press == 0 then
+                if arp[i].enabled and grid_pat[i].rec == 0 and not arp[i].pause then
+                  if arp[i].down == 0 and params:string("arp_"..i.."_hold_style") == "last pressed" then
+                    for j = #arp[i].notes,1,-1 do
+                      table.remove(arp[i].notes,j)
+                    end
                   end
+                  arp[i].time = bank[i][bank[i].id].arp_time
+                  arps.momentary(i, bank[i].id, "on")
+                  arp[i].down = arp[i].down + 1
+                else
+                  if rytm.track[i].k == 0 then
+                    cheat(i, bank[i].id)
+                  end
+                  grid_pattern_watch(i)
                 end
-                arp[i].time = bank[i][bank[i].id].arp_time
-                arps.momentary(i, bank[i].id, "on")
-                arp[i].down = arp[i].down + 1
               else
-                if rytm.track[i].k == 0 then
-                  cheat(i, bank[i].id)
-                end
-                grid_pattern_watch(i)
+                table.insert(quantize_events[i],selected[i].id)
               end
             else
-              table.insert(quantize_events[i],selected[i].id)
+              local released_pad = (math.abs(y-9)+((x-1)*4))-(20*(i-1))
+              arps.momentary(i, released_pad, "off")
             end
           else
+            if not grid.alt then
+              bank[i].focus_pad = (math.abs(y-9)+((x-1)*4))-(20*(i-1))
+              mc.mft_redraw(bank[i][bank[i].focus_pad],"all")
+            elseif grid.alt then
+              if not pad_clipboard then
+                pad_clipboard = {}
+                bank[i].focus_pad = (math.abs(y-9)+((x-1)*4))-(20*(i-1))
+                pad_copy(pad_clipboard, bank[i][bank[i].focus_pad])
+              else
+                bank[i].focus_pad = (math.abs(y-9)+((x-1)*4))-(20*(i-1))
+                pad_copy(bank[i][bank[i].focus_pad], pad_clipboard)
+                pad_clipboard = nil
+              end
+            end
+          end
+          if menu ~= 1 then screen_dirty = true end
+        elseif z == 0 and x > 0 + (5*(i-1)) and x <= 4 + (5*(i-1)) and y >=5 then
+          if not bank[i].focus_hold then
             local released_pad = (math.abs(y-9)+((x-1)*4))-(20*(i-1))
-            arps.momentary(i, released_pad, "off")
-          end
-        else
-          if not grid.alt then
-            bank[i].focus_pad = (math.abs(y-9)+((x-1)*4))-(20*(i-1))
-            mc.mft_redraw(bank[i][bank[i].focus_pad],"all")
-          elseif grid.alt then
-            if not pad_clipboard then
-              pad_clipboard = {}
-              bank[i].focus_pad = (math.abs(y-9)+((x-1)*4))-(20*(i-1))
-              pad_copy(pad_clipboard, bank[i][bank[i].focus_pad])
-            else
-              bank[i].focus_pad = (math.abs(y-9)+((x-1)*4))-(20*(i-1))
-              pad_copy(bank[i][bank[i].focus_pad], pad_clipboard)
-              pad_clipboard = nil
+            if bank[i][released_pad].play_mode == "momentary" then
+              softcut.rate(i+1,0)
+            end
+            if (arp[i].enabled and not arp[i].hold) or (menu == 9 and not arp[i].hold) then
+              arps.momentary(i, released_pad, "off")
+              arp[i].down = arp[i].down - 1
+            elseif (arp[i].enabled and arp[i].hold and not arp[i].pause) or (menu == 9 and arp[i].hold and not arp[i].pause) then
+              arp[i].down = arp[i].down - 1
             end
           end
         end
-        if menu ~= 1 then screen_dirty = true end
-      elseif z == 0 and x > 0 + (5*(i-1)) and x <= 4 + (5*(i-1)) and y >=5 then
-        if not bank[i].focus_hold then
-          local released_pad = (math.abs(y-9)+((x-1)*4))-(20*(i-1))
-          if bank[i][released_pad].play_mode == "momentary" then
-            softcut.rate(i+1,0)
-          end
-          if (arp[i].enabled and not arp[i].hold) or (menu == 9 and not arp[i].hold) then
-            arps.momentary(i, released_pad, "off")
-            arp[i].down = arp[i].down - 1
-          elseif (arp[i].enabled and arp[i].hold and not arp[i].pause) or (menu == 9 and arp[i].hold and not arp[i].pause) then
-            arp[i].down = arp[i].down - 1
-          end
-        end
       end
-    end
-    
-    -- zilchmo 3+4 handling
-    if x == 4 or x == 5 or x == 9 or x == 10 or x == 14 or x == 15 then
-      if ((x == 4 or x == 9 or x == 14) and y <= 3) or ((x == 5 or x == 10 or x == 15) and y <= 4) then
-        local zilch_id = x%5 == 0 and 4 or 3
-        local zmap = zilches[zilch_id]
-        local k1 = util.round(x/5)
-        local k2 = zilch_id == 3 and 4-y or 5-y
-        if z == 1 then
-          zmap[k1][k2] = true
-          zmap[k1].held = zmap[k1].held + 1
-          zilch_leds[zilch_id][k1][y] = 1
-          grid_dirty = true
-        elseif z == 0 then
-          if zmap[k1].held > 0 then
-            local coll = {}
-            for j = 1,4 do
-              if zmap[k1][j] == true then
-                table.insert(coll,j)
+      
+      -- zilchmo 3+4 handling
+      if x == 4 or x == 5 or x == 9 or x == 10 or x == 14 or x == 15 then
+        if ((x == 4 or x == 9 or x == 14) and y <= 3) or ((x == 5 or x == 10 or x == 15) and y <= 4) then
+          local zilch_id = x%5 == 0 and 4 or 3
+          local zmap = zilches[zilch_id]
+          local k1 = util.round(x/5)
+          local k2 = zilch_id == 3 and 4-y or 5-y
+          if z == 1 then
+            zmap[k1][k2] = true
+            zmap[k1].held = zmap[k1].held + 1
+            zilch_leds[zilch_id][k1][y] = 1
+            grid_dirty = true
+          elseif z == 0 then
+            if zmap[k1].held > 0 then
+              local coll = {}
+              for j = 1,4 do
+                if zmap[k1][j] == true then
+                  table.insert(coll,j)
+                end
+              end
+              coll.con = table.concat(coll)
+              local previous_rate = bank[k1][bank[k1].id].rate
+              rightangleslice.init(zilch_id,k1,coll.con)
+              if zilch_id == 4 then
+                record_zilchmo_4(previous_rate,k1,4,coll.con)
+              end
+              for j = 1,4 do
+                zmap[k1][j] = false
               end
             end
-            coll.con = table.concat(coll)
-            local previous_rate = bank[k1][bank[k1].id].rate
-            rightangleslice.init(zilch_id,k1,coll.con)
-            if zilch_id == 4 then
-              record_zilchmo_4(previous_rate,k1,4,coll.con)
-            end
-            for j = 1,4 do
-              zmap[k1][j] = false
-            end
+            zmap[k1].held = 0
+            zilch_leds[zilch_id][k1][y] = 0
+            grid_dirty = true
+            if menu ~= 1 then screen_dirty = true end
           end
-          zmap[k1].held = 0
-          zilch_leds[zilch_id][k1][y] = 0
-          grid_dirty = true
-          if menu ~= 1 then screen_dirty = true end
         end
       end
-    end
-    --/ zilchmo 3+4 handling
+      --/ zilchmo 3+4 handling
 
-    if x == 3 or x == 8 or x == 13 then
-      if y <= 2 then
-        local zilch_id = 2
-        local zmap = zilches[zilch_id]
-        local k1 = util.round(x/5)
-        local k2 = 3-y
-        if z == 1 then
-          zmap[k1][k2] = true
-          zmap[k1].held = zmap[k1].held + 1
-          zilch_leds[zilch_id][k1][y] = 1
-          grid_dirty = true
-        elseif z == 0 then
-          if zmap[k1].held > 0 then
-            local coll = {}
-            for j = 1,4 do
-              if zmap[k1][j] == true then
-                table.insert(coll,j)
+      if x == 3 or x == 8 or x == 13 then
+        if y <= 2 then
+          local zilch_id = 2
+          local zmap = zilches[zilch_id]
+          local k1 = util.round(x/5)
+          local k2 = 3-y
+          if z == 1 then
+            zmap[k1][k2] = true
+            zmap[k1].held = zmap[k1].held + 1
+            zilch_leds[zilch_id][k1][y] = 1
+            grid_dirty = true
+          elseif z == 0 then
+            if zmap[k1].held > 0 then
+              local coll = {}
+              for j = 1,4 do
+                if zmap[k1][j] == true then
+                  table.insert(coll,j)
+                end
+              end
+              coll.con = table.concat(coll)
+              local previous_rate = bank[k1][bank[k1].id].rate
+              rightangleslice.init(2,k1,coll.con)
+              for j = 1,4 do
+                zmap[k1][j] = false
               end
             end
-            coll.con = table.concat(coll)
-            local previous_rate = bank[k1][bank[k1].id].rate
-            rightangleslice.init(2,k1,coll.con)
-            for j = 1,4 do
-              zmap[k1][j] = false
-            end
+            zmap[k1].held = 0
+            zilch_leds[zilch_id][k1][y] = 0
+            grid_dirty = true
+            if menu ~= 1 then screen_dirty = true end
           end
-          zmap[k1].held = 0
-          zilch_leds[zilch_id][k1][y] = 0
-          grid_dirty = true
-          if menu ~= 1 then screen_dirty = true end
         end
       end
-    end
 
-    
-    for k = 1,1 do
-      for i = 1,3 do
-        if z == 0 and x == (k+1)+(5*(i-1)) and y<=k then
-          if grid_pat[i].quantize == 0 then -- still relevant
-            if bank[i].alt_lock and not grid.alt then
-              if grid_pat[i].play == 1 then
-                grid_pat[i].overdub = grid_pat[i].overdub == 0 and 1 or 0
+      
+      for k = 1,1 do
+        for i = 1,3 do
+          if z == 0 and x == (k+1)+(5*(i-1)) and y<=k then
+            if grid_pat[i].quantize == 0 then -- still relevant
+              if bank[i].alt_lock and not grid.alt then
+                if grid_pat[i].play == 1 then
+                  grid_pat[i].overdub = grid_pat[i].overdub == 0 and 1 or 0
+                end
+              else
+                if grid.alt then -- still relevant
+                  grid_pat[i]:rec_stop()
+                  grid_pat[i]:stop()
+                  --grid_pat[i].external_start = 0
+                  grid_pat[i].tightened_start = 0
+                  grid_pat[i]:clear()
+                  pattern_saver[i].load_slot = 0
+                elseif grid_pat[i].rec == 1 then -- still relevant
+                  grid_pat[i]:rec_stop()
+                  midi_clock_linearize(i)
+                  if grid_pat[i].auto_snap == 1 then
+                    print("auto-snap")
+                    snap_to_bars(i,how_many_bars(i))
+                  end
+                  if grid_pat[i].mode ~= "quantized" then
+                    --grid_pat[i]:start()
+                    start_pattern(grid_pat[i])
+                  --TODO: CONFIRM THIS IS OK...
+                  elseif grid_pat[i].mode == "quantized" then
+                    start_pattern(grid_pat[i])
+                  end
+                  grid_pat[i].loop = 1
+                elseif grid_pat[i].count == 0 then
+                  if grid_pat[i].playmode ~= 2 then
+                    grid_pat[i]:rec_start()
+                  --new!
+                  else
+                    grid_pat[i].rec_clock = clock.run(synced_record_start,grid_pat[i],i)
+                  end
+                  --/new!
+                elseif grid_pat[i].play == 1 then
+                  --grid_pat[i]:stop()
+                  stop_pattern(grid_pat[i])
+                else
+                  start_pattern(grid_pat[i])
+                end
               end
             else
-              if grid.alt then -- still relevant
+              if grid.alt then
                 grid_pat[i]:rec_stop()
                 grid_pat[i]:stop()
-                --grid_pat[i].external_start = 0
                 grid_pat[i].tightened_start = 0
                 grid_pat[i]:clear()
                 pattern_saver[i].load_slot = 0
-              elseif grid_pat[i].rec == 1 then -- still relevant
-                grid_pat[i]:rec_stop()
-                midi_clock_linearize(i)
-                if grid_pat[i].auto_snap == 1 then
-                  print("auto-snap")
-                  snap_to_bars(i,how_many_bars(i))
-                end
-                if grid_pat[i].mode ~= "quantized" then
-                  --grid_pat[i]:start()
-                  start_pattern(grid_pat[i])
-                --TODO: CONFIRM THIS IS OK...
-                elseif grid_pat[i].mode == "quantized" then
-                  start_pattern(grid_pat[i])
-                end
-                grid_pat[i].loop = 1
-              elseif grid_pat[i].count == 0 then
-                if grid_pat[i].playmode ~= 2 then
-                  grid_pat[i]:rec_start()
-                --new!
-                else
-                  grid_pat[i].rec_clock = clock.run(synced_record_start,grid_pat[i],i)
-                end
-                --/new!
-              elseif grid_pat[i].play == 1 then
-                --grid_pat[i]:stop()
-                stop_pattern(grid_pat[i])
               else
-                start_pattern(grid_pat[i])
+                --table.insert(grid_pat_quantize_events[i],i)
+                better_grid_pat_q_clock(i)
               end
             end
+            if menu == 11 then
+              help_menu = "grid patterns"
+              which_bank = i
+            end
+          end
+        end
+      end
+      
+      for i = 4,2,-1 do
+        if x == 16 and y == i and z == 0 then
+          local current = math.abs(y-5)
+          local a_p; -- this will index the arc encoder recorders
+          if arc_param[current] == 1 or arc_param[current] == 2 or arc_param[current] == 3 then
+            a_p = 1
           else
-            if grid.alt then
-              grid_pat[i]:rec_stop()
-              grid_pat[i]:stop()
-              grid_pat[i].tightened_start = 0
-              grid_pat[i]:clear()
-              pattern_saver[i].load_slot = 0
-            else
-              --table.insert(grid_pat_quantize_events[i],i)
-              better_grid_pat_q_clock(i)
-            end
+            a_p = arc_param[current] - 2
           end
-          if menu == 11 then
-            help_menu = "grid patterns"
-            which_bank = i
-          end
-        end
-      end
-    end
-    
-    for i = 4,2,-1 do
-      if x == 16 and y == i and z == 0 then
-        local current = math.abs(y-5)
-        local a_p; -- this will index the arc encoder recorders
-        if arc_param[current] == 1 or arc_param[current] == 2 or arc_param[current] == 3 then
-          a_p = 1
-        else
-          a_p = arc_param[current] - 2
-        end
-        if grid.alt then
-          arc_pat[current][a_p]:rec_stop()
-          arc_pat[current][a_p]:stop()
-          arc_pat[current][a_p]:clear()
-        elseif arc_pat[current][a_p].rec == 1 then
-          arc_pat[current][a_p]:rec_stop()
-          arc_pat[current][a_p]:start()
-        elseif arc_pat[current][a_p].count == 0 then
-          arc_pat[current][a_p]:rec_start()
-        elseif arc_pat[current][a_p].play == 1 then
-          arc_pat[current][a_p]:stop()
-        else
-          arc_pat[current][a_p]:start()
-        end
-        if menu == 11 then
-          help_menu = "arc patterns"
-          which_bank = current
-        end
-      end
-    end
-    
-    for i = 1,3 do
-      if x == (3)+(5*(i-1)) and y == 4 and z == 1 then
-        grid_actions.toggle_pad_loop(i)
-      end
-    end
-    
-    if x == 16 and y == 8 then
-      -- if grid.alt_pp == 1 then
-      --   grid.alt_pp = 0
-      -- end
-      -- if grid.alt_delay then
-      --   grid.alt_delay = false
-      -- end
-      grid.alt = z == 1 and true or false
-      arc.alt = z
-      if menu == 11 then
-        if grid.alt then
-          help_menu = "alt"
-        elseif not grid.alt then
-          help_menu = "welcome"
-        end
-      end
-      if menu ~= 1 then screen_dirty = true end
-      -- grid_redraw()
-    end
-    
-    if y == 4 or y == 3 or y == 2 then
-      if x == 1 or x == 6 or x == 11 then
-        local which_pad = nil
-        local current = util.round(math.sqrt(math.abs(x-2)))
-        if z == 1 then
-          if not bank[current].alt_lock and not grid.alt then
-            if bank[current].focus_hold == false then
-              jump_clip(current, bank[current].id, math.abs(y-5))
-            else
-              jump_clip(current, bank[current].focus_pad, math.abs(y-5))
-            end
-          elseif bank[current].alt_lock or grid.alt then
-            for j = 1,16 do
-              jump_clip(current, j, math.abs(y-5))
-            end
-          end
-        end
-        if z == 0 then
-          if menu ~= 1 then screen_dirty = true end
-          if bank[current].focus_hold == false then
-            if params:string("preview_clip_change") == "yes" or bank[current][bank[current].id].loop then
-              cheat(current,bank[current].id)
-            end
-          end
-        end
-      end
-    end
-    
-    for i = 4,3,-1 do
-      for j = 2,12,5 do
-        if x == j and y == i and z == 1 then
-          local which_pad = nil
-          
-          if not bank[math.sqrt(math.abs(x-3))].alt_lock and not grid.alt then
-            local current = math.sqrt(math.abs(x-3))
-            local target = bank[current].focus_hold == false and bank[current][bank[current].id] or bank[current][bank[current].focus_pad]
-            local old_mode = target.mode
-            target.mode = math.abs(i-5)
-            if old_mode ~= target.mode then
-              change_mode(target, old_mode)
-            end
-
-          elseif bank[math.sqrt(math.abs(x-3))].alt_lock or grid.alt then
-            for k = 1,16 do
-              local current = math.sqrt(math.abs(x-3))
-              local old_mode = bank[current][k].mode
-              bank[current][k].mode = math.abs(i-5)
-              if old_mode ~= bank[current][k].mode then
-                change_mode(bank[current][k], old_mode)
-              end
-            end
-          end
-
-          local current = math.sqrt(math.abs(x-3))
-          if bank[current].focus_hold == false then
-            which_pad = bank[current].id
-          else
-            which_pad = bank[current].focus_pad
-          end
-
-
-          if bank[current].focus_hold == false then
-            if params:string("preview_clip_change") == "yes" then
-              local current = math.sqrt(math.abs(x-3))
-              cheat(current,bank[current].id)
-            end
-          end
-
-          if menu == 11 then
-            which_bank = current
-            help_menu = "mode"
-          end
-        end
-      end
-    end
-    
-    for i = 7,5,-1 do
-      if x == 16 and z == 1 and y == i then
-        if rec.focus ~= 8-y then
-          rec.focus = 8-y
-        else
-          toggle_buffer(8-y)
           if grid.alt then
-            buff_flush()
+            arc_pat[current][a_p]:rec_stop()
+            arc_pat[current][a_p]:stop()
+            arc_pat[current][a_p]:clear()
+          elseif arc_pat[current][a_p].rec == 1 then
+            arc_pat[current][a_p]:rec_stop()
+            arc_pat[current][a_p]:start()
+          elseif arc_pat[current][a_p].count == 0 then
+            arc_pat[current][a_p]:rec_start()
+          elseif arc_pat[current][a_p].play == 1 then
+            arc_pat[current][a_p]:stop()
+          else
+            arc_pat[current][a_p]:start()
           end
-          
           if menu == 11 then
-            help_menu = "buffer switch"
+            help_menu = "arc patterns"
+            which_bank = current
           end
         end
       end
-    end
-    
-
-    for i = 8,6,-1 do
-      if x == 5 or x == 10 or x == 15 then
-        if y == i then
-          if not grid.alt then
-            if z == 1 then
-              table.insert(arc_switcher[x/5],y)
-              held_query[x/5] = #arc_switcher[x/5]
-            elseif z == 0 then
-              held_query[x/5] = held_query[x/5] - 1
-              if held_query[x/5] == 0 then
-                if #arc_switcher[x/5] == 1 then
-                  if arc_switcher[x/5][1] == 8 then
-                    arc_param[x/5] = 1
-                  elseif arc_switcher[x/5][1] == 7 then
-                    arc_param[x/5] = 2
-                  elseif arc_switcher[x/5][1] == 6 then
-                    arc_param[x/5] = 3
-                  end
-                elseif #arc_switcher[x/5] == 2 then
-                  total = arc_switcher[x/5][1] + arc_switcher[x/5][2]
-                  if total == 15 then
-                    arc_param[x/5] = 5
-                  elseif total == 13 then
-                    arc_param[x/5] = 6
-                  end
-                elseif #arc_switcher[x/5] == 3 then
-                  arc_param[x/5] = 4
-                elseif #arc_switcher[x/5] > 3 then
-                  arc_switcher[x/5] = {}
-                end
-                arc_switcher[x/5] = {}
-              end
-            end
-          elseif grid.alt then
-            if y == 8 then
-              -- sixteen_slices(x/5)
-            elseif y == 7 then
-              rec_to_pad(x/5)
-            elseif y == 6 then
-              pad_to_rec(x/5)
-            end
-          end
-        end
-      end
-    end
-    
-    if y == 5 then
-      --CROW
-      -- if z == 1 then
-      --   for i = 1,3 do
-      --     if bank[i].focus_hold == true then
-      --       if x == i*5 then
-      --         bank[i][bank[i].focus_pad].crow_pad_execute = (bank[i][bank[i].focus_pad].crow_pad_execute + 1)%2
-      --         if grid.alt then
-      --           for j = 1,16 do
-      --             bank[i][j].crow_pad_execute = bank[i][bank[i].focus_pad].crow_pad_execute
-      --           end
-      --         end
-      --       end
-      --     end
-      --   end
-      -- end
-      if x == 5 or x == 10 or x == 15 then
-        if not grid.alt then
-          bank[x/5].alt_lock = z == 1 and true or false
-        else
-          if z == 1 then
-            bank[x/5].alt_lock = not bank[x/5].alt_lock
-          end
-        end
-      end
-    end
-    
-    --- new page focus
-    for k = 4,1,-1 do
+      
       for i = 1,3 do
-        if z == 1 and x == k+(5*(i-1)) and y == k then
-          
-          ---
-          --if not grid.alt then
-          if not bank[i].alt_lock and not grid.alt then
-            if y == 3 then
-              grid_actions.arp_handler(i)
-            else
-              if key1_hold == true then key1_hold = false end
-              if y == 4 then
-                --CROW
-                bank[i][bank[i].focus_pad].crow_pad_execute = (bank[i][bank[i].focus_pad].crow_pad_execute + 1)%2
-              end
-              if menu ~= 1 then screen_dirty = true end
-            end
-          elseif bank[i].alt_lock or grid.alt then
-            if y == 2 then
-              random_grid_pat(math.ceil(x/4),3)
-            end
-            if y == 3 then
-              grid_actions.kill_arp(i)
-            end
-            if y == 4 and not bank[i].focus_hold then
-              local current = math.floor(x/5)+1
-              for j = 1,16 do
-                bank[current][j].rate = 1
-                if bank[current][j].fifth == true then
-                  bank[current][j].fifth = false
-                end
-              end
-              softcut.rate(current+1,1*bank[current][bank[current].id].offset)
-            elseif y == 4 and bank[i].focus_hold then
-              bank[i][bank[i].focus_pad].crow_pad_execute = (bank[i][bank[i].focus_pad].crow_pad_execute + 1)%2
-              for j = 1,16 do
-                bank[i][j].crow_pad_execute = bank[i][bank[i].focus_pad].crow_pad_execute
-              end
-            end
-          end
-          ---
+        if x == (3)+(5*(i-1)) and y == 4 and z == 1 then
+          grid_actions.toggle_pad_loop(i)
         end
       end
-    end
-    
-  elseif grid_page == 1 then
-    
-    if grid.loop_mod == 0 then
-    
-      for i = 1,11,5 do
-        for j = 1,8 do
-          if x == i and y == j then
-            local current = math.floor(x/5)+1
-            if z == 1 then
-              saved_pat = pattern_saver[current].saved[9-y] -- hate that this is global...
-              if step_seq[current].held == 0 then
-                pattern_saver[current].source = math.floor(x/5)+1
-                pattern_saver[current].save_slot = 9-y
-                pattern_saver[current].clock = clock.run(test_save,current)
-                -- print("starting save "..pattern_saver[current].clock)
+      
+      if x == 16 and y == 8 then
+        -- if grid.alt_pp == 1 then
+        --   grid.alt_pp = 0
+        -- end
+        -- if grid.alt_delay then
+        --   grid.alt_delay = false
+        -- end
+        grid.alt = z == 1 and true or false
+        arc.alt = z
+        if menu == 11 then
+          if grid.alt then
+            help_menu = "alt"
+          elseif not grid.alt then
+            help_menu = "welcome"
+          end
+        end
+        if menu ~= 1 then screen_dirty = true end
+        -- grid_redraw()
+      end
+      
+      if y == 4 or y == 3 or y == 2 then
+        if x == 1 or x == 6 or x == 11 then
+          local which_pad = nil
+          local current = util.round(math.sqrt(math.abs(x-2)))
+          if z == 1 then
+            if not bank[current].alt_lock and not grid.alt then
+              if bank[current].focus_hold == false then
+                jump_clip(current, bank[current].id, math.abs(y-5))
               else
-                --if there's a pattern saved there...
-                if pattern_saver[current].saved[9-y] == 1 then
-                  if not grid.alt then
-                    step_seq[current][step_seq[current].held].assigned_to = 9-y
-                  end
-                end
+                jump_clip(current, bank[current].focus_pad, math.abs(y-5))
               end
-            elseif z == 0 then
-              if step_seq[current].held == 0 then
-                if pattern_saver[math.floor(x/5)+1].clock then
-                  clock.cancel(pattern_saver[math.floor(x/5)+1].clock)
-                  -- TODO: FIX THIS OVERWRITING...
-                  -- clock.cancel(pattern_saver[math.floor(x/5)+1].clock-1)
-                  -- clock.cancel(pattern_saver[math.floor(x/5)+1].clock-2)
-                  -- print("killing save "..pattern_saver[math.floor(x/5)+1].clock)
-                end
-                pattern_saver[math.floor(x/5)+1].active = false
-                if not grid.alt and saved_pat == 1 then
-                  if pattern_saver[current].saved[9-y] == 1 then
-                    pattern_saver[current].load_slot = 9-y
-                    test_load((9-y)+(8*(current-1)),current)
-                  end
-                end
+            elseif bank[current].alt_lock or grid.alt then
+              for j = 1,16 do
+                jump_clip(current, j, math.abs(y-5))
+              end
+            end
+          end
+          if z == 0 then
+            if menu ~= 1 then screen_dirty = true end
+            if bank[current].focus_hold == false then
+              if params:string("preview_clip_change") == "yes" or bank[current][bank[current].id].loop then
+                cheat(current,bank[current].id)
               end
             end
           end
         end
       end
       
-      for i = 2,12,5 do
-        for j = 1,8 do
-          if z == 1 and x == i and y == j then
-            local current = math.floor(x/5)+1
-            step_seq[current].meta_duration = 9-y
-          end
-        end
-      end
-      
-      for i = 3,13,5 do
-        for j = 1,8 do
-          if z == 1 and x == i and y == j then
-            local current = math.floor(x/5)+1
-            step_seq[current].held = 9-y
-            if grid.alt then
-              step_seq[current][step_seq[current].held].assigned_to = 0
-            end
-          elseif z == 0 and x == i and y == j then
-            local current = math.floor(x/5)+1
-            step_seq[current].held = 0
-          elseif z == 1 and x == i+1 and y == j then
-            local current = math.floor(x/5)+1
-            step_seq[current].held = (9-y)+8
-            if grid.alt then
-              step_seq[current][step_seq[current].held].assigned_to = 0
-            end
-          elseif z == 0 and x == i+1 and y == j then
-            local current = math.floor(x/5)+1
-            step_seq[current].held = 0
-          end
-        end
-      end
-      
-      for i = 5,15,5 do
-        for j = 1,8 do
-          if z == 1 and x == i and y == j then
-            local current = x/5
-            if step_seq[current].held == 0 then
-              step_seq[current][step_seq[current].current_step].meta_meta_duration = 9-y
-            else
-              step_seq[current][step_seq[current].held].meta_meta_duration = 9-y
-            end
-            if grid.alt then
+      for i = 4,3,-1 do
+        for j = 2,12,5 do
+          if x == j and y == i and z == 1 then
+            local which_pad = nil
+            
+            if not bank[math.sqrt(math.abs(x-3))].alt_lock and not grid.alt then
+              local current = math.sqrt(math.abs(x-3))
+              local target = bank[current].focus_hold == false and bank[current][bank[current].id] or bank[current][bank[current].focus_pad]
+              local old_mode = target.mode
+              target.mode = math.abs(i-5)
+              if old_mode ~= target.mode then
+                change_mode(target, old_mode)
+              end
+
+            elseif bank[math.sqrt(math.abs(x-3))].alt_lock or grid.alt then
               for k = 1,16 do
-                step_seq[current][k].meta_meta_duration = 9-y
+                local current = math.sqrt(math.abs(x-3))
+                local old_mode = bank[current][k].mode
+                bank[current][k].mode = math.abs(i-5)
+                if old_mode ~= bank[current][k].mode then
+                  change_mode(bank[current][k], old_mode)
+                end
               end
+            end
+
+            local current = math.sqrt(math.abs(x-3))
+            if bank[current].focus_hold == false then
+              which_pad = bank[current].id
+            else
+              which_pad = bank[current].focus_pad
+            end
+
+
+            if bank[current].focus_hold == false then
+              if params:string("preview_clip_change") == "yes" then
+                local current = math.sqrt(math.abs(x-3))
+                cheat(current,bank[current].id)
+              end
+            end
+
+            if menu == 11 then
+              which_bank = current
+              help_menu = "mode"
             end
           end
         end
       end
       
       for i = 7,5,-1 do
-        if x == 16 and y == i and z == 1 then
-          if step_seq[8-i].held == 0 then
-            if grid.alt then
-              clock.run(reset_step_seq,y)
-              -- step_seq[8-i].current_step = step_seq[8-i].start_point
-              -- step_seq[8-i].meta_step = 1
-              -- step_seq[8-i].meta_meta_step = 1
-              -- if step_seq[8-i].active == 1 and step_seq[8-i][step_seq[8-i].current_step].assigned_to ~= 0 then
-              --   test_load(step_seq[8-i][step_seq[8-i].current_step].assigned_to+(((8-i)-1)*8),8-i)
-              -- end
-            else
-              step_seq[8-i].active = (step_seq[8-i].active + 1)%2
-            end
+        if x == 16 and z == 1 and y == i then
+          if rec.focus ~= 8-y then
+            rec.focus = 8-y
           else
-            step_seq[8-i][step_seq[8-i].held].loop_pattern = (step_seq[8-i][step_seq[8-i].held].loop_pattern + 1)%2
+            toggle_buffer(8-y)
+            if grid.alt then
+              buff_flush()
+            end
+            
+            if menu == 11 then
+              help_menu = "buffer switch"
+            end
           end
         end
       end
+      
 
-      function reset_step_seq(i) -- TODO: funky on some...
-        step_seq[8-i].active = (step_seq[8-i].active + 1)%2
-        step_seq[8-i].meta_meta_step = 1
-        step_seq[8-i].meta_step = 1
-        step_seq[8-i].current_step = step_seq[8-i].start_point
-        clock.sync(1)
-        step_seq[8-i].active = (step_seq[8-i].active + 1)%2
-        if step_seq[8-i].active == 1 and step_seq[8-i][step_seq[8-i].current_step].assigned_to ~= 0 then
-          test_load(step_seq[8-i][step_seq[8-i].current_step].assigned_to+(((8-i)-1)*8),8-i)
+      for i = 8,6,-1 do
+        if x == 5 or x == 10 or x == 15 then
+          if y == i then
+            if not grid.alt then
+              if z == 1 then
+                table.insert(arc_switcher[x/5],y)
+                held_query[x/5] = #arc_switcher[x/5]
+              elseif z == 0 then
+                held_query[x/5] = held_query[x/5] - 1
+                if held_query[x/5] == 0 then
+                  if #arc_switcher[x/5] == 1 then
+                    if arc_switcher[x/5][1] == 8 then
+                      arc_param[x/5] = 1
+                    elseif arc_switcher[x/5][1] == 7 then
+                      arc_param[x/5] = 2
+                    elseif arc_switcher[x/5][1] == 6 then
+                      arc_param[x/5] = 3
+                    end
+                  elseif #arc_switcher[x/5] == 2 then
+                    total = arc_switcher[x/5][1] + arc_switcher[x/5][2]
+                    if total == 15 then
+                      arc_param[x/5] = 5
+                    elseif total == 13 then
+                      arc_param[x/5] = 6
+                    end
+                  elseif #arc_switcher[x/5] == 3 then
+                    arc_param[x/5] = 4
+                  elseif #arc_switcher[x/5] > 3 then
+                    arc_switcher[x/5] = {}
+                  end
+                  arc_switcher[x/5] = {}
+                end
+              end
+            elseif grid.alt then
+              if y == 8 then
+                -- sixteen_slices(x/5)
+              elseif y == 7 then
+                rec_to_pad(x/5)
+              elseif y == 6 then
+                pad_to_rec(x/5)
+              end
+            end
+          end
         end
       end
       
+      if y == 5 then
+        --CROW
+        -- if z == 1 then
+        --   for i = 1,3 do
+        --     if bank[i].focus_hold == true then
+        --       if x == i*5 then
+        --         bank[i][bank[i].focus_pad].crow_pad_execute = (bank[i][bank[i].focus_pad].crow_pad_execute + 1)%2
+        --         if grid.alt then
+        --           for j = 1,16 do
+        --             bank[i][j].crow_pad_execute = bank[i][bank[i].focus_pad].crow_pad_execute
+        --           end
+        --         end
+        --       end
+        --     end
+        --   end
+        -- end
+        if x == 5 or x == 10 or x == 15 then
+          if not grid.alt then
+            bank[x/5].alt_lock = z == 1 and true or false
+          else
+            if z == 1 then
+              bank[x/5].alt_lock = not bank[x/5].alt_lock
+            end
+          end
+        end
+      end
       
-      if x == 16 and y == 8 then
-        grid.alt = z == 1 and true or false
+      --- new page focus
+      for k = 4,1,-1 do
+        for i = 1,3 do
+          if z == 1 and x == k+(5*(i-1)) and y == k then
+            
+            ---
+            --if not grid.alt then
+            if not bank[i].alt_lock and not grid.alt then
+              if y == 3 then
+                grid_actions.arp_handler(i)
+              else
+                if key1_hold == true then key1_hold = false end
+                if y == 4 then
+                  --CROW
+                  bank[i][bank[i].focus_pad].crow_pad_execute = (bank[i][bank[i].focus_pad].crow_pad_execute + 1)%2
+                end
+                if menu ~= 1 then screen_dirty = true end
+              end
+            elseif bank[i].alt_lock or grid.alt then
+              if y == 2 then
+                random_grid_pat(math.ceil(x/4),3)
+              end
+              if y == 3 then
+                grid_actions.kill_arp(i)
+              end
+              if y == 4 and not bank[i].focus_hold then
+                local current = math.floor(x/5)+1
+                for j = 1,16 do
+                  bank[current][j].rate = 1
+                  if bank[current][j].fifth == true then
+                    bank[current][j].fifth = false
+                  end
+                end
+                softcut.rate(current+1,1*bank[current][bank[current].id].offset)
+              elseif y == 4 and bank[i].focus_hold then
+                bank[i][bank[i].focus_pad].crow_pad_execute = (bank[i][bank[i].focus_pad].crow_pad_execute + 1)%2
+                for j = 1,16 do
+                  bank[i][j].crow_pad_execute = bank[i][bank[i].focus_pad].crow_pad_execute
+                end
+              end
+            end
+            ---
+          end
+        end
+      end
+      
+    elseif grid_page == 1 then
+      
+      if grid.loop_mod == 0 then
+      
+        for i = 1,11,5 do
+          for j = 1,8 do
+            if x == i and y == j then
+              local current = math.floor(x/5)+1
+              if z == 1 then
+                saved_pat = pattern_saver[current].saved[9-y] -- hate that this is global...
+                if step_seq[current].held == 0 then
+                  pattern_saver[current].source = math.floor(x/5)+1
+                  pattern_saver[current].save_slot = 9-y
+                  pattern_saver[current].clock = clock.run(test_save,current)
+                  -- print("starting save "..pattern_saver[current].clock)
+                else
+                  --if there's a pattern saved there...
+                  if pattern_saver[current].saved[9-y] == 1 then
+                    if not grid.alt then
+                      step_seq[current][step_seq[current].held].assigned_to = 9-y
+                    end
+                  end
+                end
+              elseif z == 0 then
+                if step_seq[current].held == 0 then
+                  if pattern_saver[math.floor(x/5)+1].clock then
+                    clock.cancel(pattern_saver[math.floor(x/5)+1].clock)
+                    -- TODO: FIX THIS OVERWRITING...
+                    -- clock.cancel(pattern_saver[math.floor(x/5)+1].clock-1)
+                    -- clock.cancel(pattern_saver[math.floor(x/5)+1].clock-2)
+                    -- print("killing save "..pattern_saver[math.floor(x/5)+1].clock)
+                  end
+                  pattern_saver[math.floor(x/5)+1].active = false
+                  if not grid.alt and saved_pat == 1 then
+                    if pattern_saver[current].saved[9-y] == 1 then
+                      pattern_saver[current].load_slot = 9-y
+                      test_load((9-y)+(8*(current-1)),current)
+                    end
+                  end
+                end
+              end
+            end
+          end
+        end
+        
+        for i = 2,12,5 do
+          for j = 1,8 do
+            if z == 1 and x == i and y == j then
+              local current = math.floor(x/5)+1
+              step_seq[current].meta_duration = 9-y
+            end
+          end
+        end
+        
+        for i = 3,13,5 do
+          for j = 1,8 do
+            if z == 1 and x == i and y == j then
+              local current = math.floor(x/5)+1
+              step_seq[current].held = 9-y
+              if grid.alt then
+                step_seq[current][step_seq[current].held].assigned_to = 0
+              end
+            elseif z == 0 and x == i and y == j then
+              local current = math.floor(x/5)+1
+              step_seq[current].held = 0
+            elseif z == 1 and x == i+1 and y == j then
+              local current = math.floor(x/5)+1
+              step_seq[current].held = (9-y)+8
+              if grid.alt then
+                step_seq[current][step_seq[current].held].assigned_to = 0
+              end
+            elseif z == 0 and x == i+1 and y == j then
+              local current = math.floor(x/5)+1
+              step_seq[current].held = 0
+            end
+          end
+        end
+        
+        for i = 5,15,5 do
+          for j = 1,8 do
+            if z == 1 and x == i and y == j then
+              local current = x/5
+              if step_seq[current].held == 0 then
+                step_seq[current][step_seq[current].current_step].meta_meta_duration = 9-y
+              else
+                step_seq[current][step_seq[current].held].meta_meta_duration = 9-y
+              end
+              if grid.alt then
+                for k = 1,16 do
+                  step_seq[current][k].meta_meta_duration = 9-y
+                end
+              end
+            end
+          end
+        end
+        
+        for i = 7,5,-1 do
+          if x == 16 and y == i and z == 1 then
+            if step_seq[8-i].held == 0 then
+              if grid.alt then
+                clock.run(reset_step_seq,y)
+                -- step_seq[8-i].current_step = step_seq[8-i].start_point
+                -- step_seq[8-i].meta_step = 1
+                -- step_seq[8-i].meta_meta_step = 1
+                -- if step_seq[8-i].active == 1 and step_seq[8-i][step_seq[8-i].current_step].assigned_to ~= 0 then
+                --   test_load(step_seq[8-i][step_seq[8-i].current_step].assigned_to+(((8-i)-1)*8),8-i)
+                -- end
+              else
+                step_seq[8-i].active = (step_seq[8-i].active + 1)%2
+              end
+            else
+              step_seq[8-i][step_seq[8-i].held].loop_pattern = (step_seq[8-i][step_seq[8-i].held].loop_pattern + 1)%2
+            end
+          end
+        end
+
+        function reset_step_seq(i) -- TODO: funky on some...
+          step_seq[8-i].active = (step_seq[8-i].active + 1)%2
+          step_seq[8-i].meta_meta_step = 1
+          step_seq[8-i].meta_step = 1
+          step_seq[8-i].current_step = step_seq[8-i].start_point
+          clock.sync(1)
+          step_seq[8-i].active = (step_seq[8-i].active + 1)%2
+          if step_seq[8-i].active == 1 and step_seq[8-i][step_seq[8-i].current_step].assigned_to ~= 0 then
+            test_load(step_seq[8-i][step_seq[8-i].current_step].assigned_to+(((8-i)-1)*8),8-i)
+          end
+        end
+        
+        
+        if x == 16 and y == 8 then
+          grid.alt = z == 1 and true or false
+          if menu ~= 1 then screen_dirty = true end
+          -- grid_redraw()
+        end
+      
+      elseif grid.loop_mod == 1 then
+        for i = 3,13,5 do
+          if x == i or x == i+1 then
+            local current = math.floor(x/5)+1
+            if z == 1 then
+              step_seq[current].loop_held = step_seq[current].loop_held + 1
+              if step_seq[current].loop_held == 1 then
+                if x == i then
+                  step_seq[current].start_point = 9-y
+                elseif x == i+1 then
+                  step_seq[current].start_point = 17-y
+                end
+                if step_seq[current].start_point > step_seq[current].current_step then
+                  step_seq[current].current_step = step_seq[current].start_point
+                end
+              elseif step_seq[current].loop_held == 2 then
+                if x == i then
+                  step_seq[current].end_point = 9-y
+                elseif x == i+1 then
+                  step_seq[current].end_point = 17-y
+                end
+              end
+            elseif z == 0 then
+              step_seq[current].loop_held = step_seq[current].loop_held - 1
+            end
+          end
+        end
+      end
+      
+      if x == 16 and y == 2 then
+        grid.loop_mod = z
         if menu ~= 1 then screen_dirty = true end
         -- grid_redraw()
       end
+      
+      if menu == 11 then
+        if x == 1 or x == 6 or x == 11 then
+          help_menu = "meta: slots"
+        elseif x == 2 or x == 7 or x == 12 then
+          help_menu = "meta: clock"
+        elseif x == 3 or x == 4 or x == 8 or x == 9 or x == 13 or x == 14 then
+          if grid.loop_mod == 0 then
+            help_menu = "meta: step"
+          end
+        elseif x == 5 or x == 10 or x == 15 then
+          help_menu = "meta: duration"
+        elseif x == 16 then
+          if y == 8 then
+            if z == 1 then
+              help_menu = "meta: alt"
+            elseif z == 0 then
+              help_menu = "welcome"
+            end
+          elseif y == 7 or y == 6 or y == 5 then
+            help_menu = "meta: toggle"
+          elseif y == 2 then
+            if z == 1 then
+              help_menu = "meta: loop mod"
+            elseif z == 0 then
+              help_menu = "welcome"
+            end
+          end
+        end
+        if menu ~= 1 then screen_dirty = true end
+      end
     
-    elseif grid.loop_mod == 1 then
-      for i = 3,13,5 do
-        if x == i or x == i+1 then
-          local current = math.floor(x/5)+1
+    elseif grid_page == 2 then
+      if y == 3 or y == 6 then
+        if x <= 2 and z == 1 then
+          local changes = {"double", "halve", "sync"}
+          del.change_duration(y == 6 and 1 or 2, y == 6 and 2 or 1, changes[x])
+        elseif x == 3 and z == 1 then
+          del.quick_action(y == 6 and 1 or 2, "reverse")
+        elseif x >= 4 and x <= 8 then
           if z == 1 then
-            step_seq[current].loop_held = step_seq[current].loop_held + 1
-            if step_seq[current].loop_held == 1 then
-              if x == i then
-                step_seq[current].start_point = 9-y
-              elseif x == i+1 then
-                step_seq[current].start_point = 17-y
-              end
-              if step_seq[current].start_point > step_seq[current].current_step then
-                step_seq[current].current_step = step_seq[current].start_point
-              end
-            elseif step_seq[current].loop_held == 2 then
-              if x == i then
-                step_seq[current].end_point = 9-y
-              elseif x == i+1 then
-                step_seq[current].end_point = 17-y
+            del.set_value(math.abs(5-y), x-3, "level")
+          end
+        elseif x == 9 then
+          del.quick_action(math.abs(y-5),"level_mute",z)
+        end
+      elseif y == 4 or y == 5 then
+        if x >= 4 and x <= 8 then
+          if z == 1 then
+            del.set_value(6-y, x-3, "feedback")
+          end
+        elseif x == 9 then
+          -- if grid.alt_delay then
+          if grid.alt then
+            del.quick_action(6-y, "clear")
+          end
+          del.quick_action(6-y,"feedback_mute",z)
+        end
+      elseif y == 1 or y == 8 then
+        if x >= 10 and x <=14 then
+          if z == 1 then
+            -- del.set_value(y == 8 and 1 or 2,x-9,grid.alt_delay == true and "send all" or "send")
+            del.set_value(y == 8 and 1 or 2,x-9,grid.alt == true and "send all" or "send")
+          end
+        elseif x == 15 then
+          del.quick_action(y == 8 and 1 or 2,"send_mute",z)
+        end
+      end
+
+      if y == 1 or y == 2 or y == 7 or y == 8 then
+        if x <= 8 then
+          if z == 1 then
+            local y_vals = {[8] = 0, [7] = 1, [2] = 0, [1] = 1}
+            local bundle = x+(8*y_vals[y])
+            local target = y<=2 and 2 or 1
+            local saved_already = delay_bundle[target][bundle].saved
+            if not saved_already then
+              delay[target].saver_active = true
+              clock.run(del.build_bundle,target,bundle)
+            elseif saved_already then
+              -- if grid.alt_delay then
+              if grid.alt then
+                del.clear_bundle(target,bundle)
+              else
+                del.restore_bundle(target,bundle)
+                delay[target].selected_bundle = bundle
               end
             end
           elseif z == 0 then
-            step_seq[current].loop_held = step_seq[current].loop_held - 1
+            delay[y<=2 and 2 or 1].saver_active = false
           end
         end
       end
-    end
-    
-    if x == 16 and y == 2 then
-      grid.loop_mod = z
-      if menu ~= 1 then screen_dirty = true end
-      -- grid_redraw()
-    end
-    
-    if menu == 11 then
-      if x == 1 or x == 6 or x == 11 then
-        help_menu = "meta: slots"
-      elseif x == 2 or x == 7 or x == 12 then
-        help_menu = "meta: clock"
-      elseif x == 3 or x == 4 or x == 8 or x == 9 or x == 13 or x == 14 then
-        if grid.loop_mod == 0 then
-          help_menu = "meta: step"
-        end
-      elseif x == 5 or x == 10 or x == 15 then
-        help_menu = "meta: duration"
-      elseif x == 16 then
-        if y == 8 then
-          if z == 1 then
-            help_menu = "meta: alt"
-          elseif z == 0 then
-            help_menu = "welcome"
-          end
-        elseif y == 7 or y == 6 or y == 5 then
-          help_menu = "meta: toggle"
-        elseif y == 2 then
-          if z == 1 then
-            help_menu = "meta: loop mod"
-          elseif z == 0 then
-            help_menu = "welcome"
-          end
-        end
-      end
-      if menu ~= 1 then screen_dirty = true end
-    end
-  
-  elseif grid_page == 2 then
-    if y == 3 or y == 6 then
-      if x <= 2 and z == 1 then
-        local changes = {"double", "halve", "sync"}
-        del.change_duration(y == 6 and 1 or 2, y == 6 and 2 or 1, changes[x])
-      elseif x == 3 and z == 1 then
-        del.quick_action(y == 6 and 1 or 2, "reverse")
-      elseif x >= 4 and x <= 8 then
-        if z == 1 then
-          del.set_value(math.abs(5-y), x-3, "level")
-        end
-      elseif x == 9 then
-        del.quick_action(math.abs(y-5),"level_mute",z)
-      end
-    elseif y == 4 or y == 5 then
-      if x >= 4 and x <= 8 then
-        if z == 1 then
-          del.set_value(6-y, x-3, "feedback")
-        end
-      elseif x == 9 then
-        -- if grid.alt_delay then
-        if grid.alt then
-          del.quick_action(6-y, "clear")
-        end
-        del.quick_action(6-y,"feedback_mute",z)
-      end
-    elseif y == 1 or y == 8 then
-      if x >= 10 and x <=14 then
-        if z == 1 then
-          -- del.set_value(y == 8 and 1 or 2,x-9,grid.alt_delay == true and "send all" or "send")
-          del.set_value(y == 8 and 1 or 2,x-9,grid.alt == true and "send all" or "send")
-        end
-      elseif x == 15 then
-        del.quick_action(y == 8 and 1 or 2,"send_mute",z)
-      end
-    end
 
-    if y == 1 or y == 2 or y == 7 or y == 8 then
-      if x <= 8 then
+      if y == 6 or y == 5 or y == 4 then
+        if x == 14 and z == 1 then
+          delay_grid.bank = 7-y
+        end
+      end
+
+      if y == 4 or y == 5 then
+        if x == 1 and z == 1 then
+          del.change_rate(6-y, "double")
+        elseif x == 2 and z == 1 then
+          del.change_rate(6-y, "halve")
+        elseif x == 3 then
+          del.change_rate(6-y,z == 1 and "wobble" or "restore")
+        end
+      end
+
+      if x == 12 and y == 2 then
         if z == 1 then
-          local y_vals = {[8] = 0, [7] = 1, [2] = 0, [1] = 1}
-          local bundle = x+(8*y_vals[y])
-          local target = y<=2 and 2 or 1
-          local saved_already = delay_bundle[target][bundle].saved
-          if not saved_already then
-            delay[target].saver_active = true
-            clock.run(del.build_bundle,target,bundle)
-          elseif saved_already then
-            -- if grid.alt_delay then
-            if grid.alt then
-              del.clear_bundle(target,bundle)
+          if grid.alt or bank[delay_grid.bank].alt_lock then
+            grid_actions.kill_arp(delay_grid.bank)
+          elseif not grid.alt and not bank[delay_grid.bank].alt_lock then
+            grid_actions.arp_handler(delay_grid.bank)
+          end
+        end
+      end
+
+      if x == 13 and y == 2 and z == 1 then
+        grid_actions.toggle_pad_loop(delay_grid.bank)
+      end
+
+      if x >= 10 and x <= 13 and y >=3 and y <=6 then
+        local id = delay_grid.bank
+        if not grid.alt then
+          if z == 1 then
+            local xval = {9,4,-1}
+            selected[id].x = x - xval[id]
+            selected[id].y = y + 2
+            selected[id].id = (math.abs(selected[id].y-9)+((selected[id].x-1)*4))-(20*(id-1))
+            bank[id].id = selected[id].id
+            -- if (arp[id].hold or (menu == 9)) and grid_pat[id].rec == 0 and not arp[id].pause then
+            if (arp[id].enabled or (menu == 9)) and grid_pat[id].rec == 0 and not arp[id].pause then
+              if arp[id].down == 0 and params:string("arp_"..id.."_hold_style") == "last pressed" then
+                for i = #arp[id].notes,1,-1 do
+                  table.remove(arp[id].notes,i)
+                end
+              end
+              arp[id].time = bank[id][bank[id].id].arp_time
+              arps.momentary(id, bank[id].id, "on")
+              arp[id].down = arp[id].down + 1
             else
-              del.restore_bundle(target,bundle)
-              delay[target].selected_bundle = bundle
+              if rytm.track[id].k == 0 then
+                cheat(id, bank[id].id)
+              end
+              grid_pattern_watch(id)
             end
-          end
-        elseif z == 0 then
-          delay[y<=2 and 2 or 1].saver_active = false
-        end
-      end
-    end
-
-    if y == 6 or y == 5 or y == 4 then
-      if x == 14 and z == 1 then
-        delay_grid.bank = 7-y
-      end
-    end
-
-    if y == 4 or y == 5 then
-      if x == 1 and z == 1 then
-        del.change_rate(6-y, "double")
-      elseif x == 2 and z == 1 then
-        del.change_rate(6-y, "halve")
-      elseif x == 3 then
-        del.change_rate(6-y,z == 1 and "wobble" or "restore")
-      end
-    end
-
-    if x == 12 and y == 2 then
-      if z == 1 then
-        if grid.alt or bank[delay_grid.bank].alt_lock then
-          grid_actions.kill_arp(delay_grid.bank)
-        elseif not grid.alt and not bank[delay_grid.bank].alt_lock then
-          grid_actions.arp_handler(delay_grid.bank)
-        end
-      end
-    end
-
-    if x == 13 and y == 2 and z == 1 then
-      grid_actions.toggle_pad_loop(delay_grid.bank)
-    end
-
-    if x >= 10 and x <= 13 and y >=3 and y <=6 then
-      local id = delay_grid.bank
-      if not grid.alt then
-        if z == 1 then
-          local xval = {9,4,-1}
-          selected[id].x = x - xval[id]
-          selected[id].y = y + 2
-          selected[id].id = (math.abs(selected[id].y-9)+((selected[id].x-1)*4))-(20*(id-1))
-          bank[id].id = selected[id].id
-          -- if (arp[id].hold or (menu == 9)) and grid_pat[id].rec == 0 and not arp[id].pause then
-          if (arp[id].enabled or (menu == 9)) and grid_pat[id].rec == 0 and not arp[id].pause then
-            if arp[id].down == 0 and params:string("arp_"..id.."_hold_style") == "last pressed" then
-              for i = #arp[id].notes,1,-1 do
-                table.remove(arp[id].notes,i)
+          else
+            -- if not arp[id].hold then
+            if not bank[id].focus_hold then
+              if arp[id].enabled and not arp[id].hold then
+                local xval = {9,4,-1}
+                local released_pad = (math.abs((y + 2)-9)+(((x - xval[id])-1)*4))-(20*(id-1))
+                arps.momentary(id, released_pad, "off")
+                arp[id].down = arp[id].down - 1
+              elseif arp[id].enabled and arp[id].hold then
+                arp[id].down = arp[id].down - 1
               end
             end
-            arp[id].time = bank[id][bank[id].id].arp_time
-            arps.momentary(id, bank[id].id, "on")
-            arp[id].down = arp[id].down + 1
-          else
-            if rytm.track[id].k == 0 then
-              cheat(id, bank[id].id)
-            end
-            grid_pattern_watch(id)
           end
         else
-          -- if not arp[id].hold then
-          if not bank[id].focus_hold then
-            if arp[id].enabled and not arp[id].hold then
-              local xval = {9,4,-1}
-              local released_pad = (math.abs((y + 2)-9)+(((x - xval[id])-1)*4))-(20*(id-1))
-              arps.momentary(id, released_pad, "off")
-              arp[id].down = arp[id].down - 1
-            elseif arp[id].enabled and arp[id].hold then
-              arp[id].down = arp[id].down - 1
-            end
+          if z == 1 then
+            local xval = {9,4,-1}
+            local released_pad = (math.abs((y + 2)-9)+(((x - xval[id])-1)*4))-(20*(id-1))
+            arps.momentary(id, released_pad, "off")
           end
         end
-      else
-        if z == 1 then
-          local xval = {9,4,-1}
-          local released_pad = (math.abs((y + 2)-9)+(((x - xval[id])-1)*4))-(20*(id-1))
-          arps.momentary(id, released_pad, "off")
-        end
       end
-    end
 
-    -- zilchmo 4!!
-    if x == 15 then
-      if y >= 3 and y <= 6 then
-        local zilch_id = 4
-        local zmap = zilches[zilch_id]
-        local k1 = delay_grid.bank
-        local k2 = 7-y
-        if z == 1 then
-          zmap[k1][k2] = true
-          zmap[k1].held = zmap[k1].held + 1
-          zilch_leds[zilch_id][k1][7-y] = 1
-          grid_dirty = true
-        elseif z == 0 then
-          if zmap[k1].held > 0 then
-            local coll = {}
-            for j = 1,4 do
-              if zmap[k1][j] == true then
-                table.insert(coll,j)
+      -- zilchmo 4!!
+      if x == 15 then
+        if y >= 3 and y <= 6 then
+          local zilch_id = 4
+          local zmap = zilches[zilch_id]
+          local k1 = delay_grid.bank
+          local k2 = 7-y
+          if z == 1 then
+            zmap[k1][k2] = true
+            zmap[k1].held = zmap[k1].held + 1
+            zilch_leds[zilch_id][k1][7-y] = 1
+            grid_dirty = true
+          elseif z == 0 then
+            if zmap[k1].held > 0 then
+              local coll = {}
+              for j = 1,4 do
+                if zmap[k1][j] == true then
+                  table.insert(coll,j)
+                end
+              end
+              coll.con = table.concat(coll)
+              local previous_rate = bank[k1][bank[k1].id].rate
+              rightangleslice.init(zilch_id,k1,coll.con)
+              if zilch_id == 4 then
+                record_zilchmo_4(previous_rate,k1,4,coll.con)
+              end
+              for j = 1,4 do
+                zmap[k1][j] = false
               end
             end
-            coll.con = table.concat(coll)
-            local previous_rate = bank[k1][bank[k1].id].rate
-            rightangleslice.init(zilch_id,k1,coll.con)
-            if zilch_id == 4 then
-              record_zilchmo_4(previous_rate,k1,4,coll.con)
-            end
-            for j = 1,4 do
-              zmap[k1][j] = false
-            end
+            zmap[k1].held = 0
+            zilch_leds[zilch_id][k1][k2] = 0
+            grid_dirty = true
+            if menu ~= 1 then screen_dirty = true end
           end
-          zmap[k1].held = 0
-          zilch_leds[zilch_id][k1][k2] = 0
-          grid_dirty = true
-          if menu ~= 1 then screen_dirty = true end
         end
       end
-    end
 
-    if x == 16 and y == 8 then
-      -- grid.alt_delay = not grid.alt_delay
-      grid.alt = not grid.alt
-    end
+      if x == 16 and y == 8 then
+        -- grid.alt_delay = not grid.alt_delay
+        grid.alt = not grid.alt
+      end
 
-  end
-  
-  if x == 16 and y == 1 and z == 1 then
-    if grid_page == 0 then
-      if not grid.alt then
-        grid_page = 1
-        if menu == 11 then
-          if grid_page == 1 then
-            help_menu = "meta page"
-          elseif grid_page == 0 then
-            help_menu = "welcome"
-          end
-          if menu ~= 1 then screen_dirty = true end
-        end
-      else
-        grid_page = 2
-        grid.alt = true
-      end
-    elseif grid_page == 1 then
-      if not grid.alt then
-        grid_page = 2
-      else
-        grid_page = 0
-      end
-    elseif grid_page == 2 then
-      if not grid.alt then
-        grid_page = 0
-      else
-        grid_page = 1
-      end
     end
-  end
-
-  grid_dirty = true
     
+    if x == 16 and y == 1 and z == 1 then
+      if grid_page == 0 then
+        if not grid.alt then
+          grid_page = 1
+          if menu == 11 then
+            if grid_page == 1 then
+              help_menu = "meta page"
+            elseif grid_page == 0 then
+              help_menu = "welcome"
+            end
+            if menu ~= 1 then screen_dirty = true end
+          end
+        else
+          grid_page = 2
+          grid.alt = true
+        end
+      elseif grid_page == 1 then
+        if not grid.alt then
+          grid_page = 2
+        else
+          grid_page = 0
+        end
+      elseif grid_page == 2 then
+        if not grid.alt then
+          grid_page = 0
+        else
+          grid_page = 1
+        end
+      end
+    end
+
+    grid_dirty = true
+    
+  elseif params:string("grid_size") == "64" then
+    if grid_page_64 == 0 then
+      
+      local b = bank[bank_64]
+
+      if x <=3 and y == 1 and z ==1  then
+        bank_64 = x
+        b = bank[x]
+      end
+      
+      if grid.alt then
+        if x == 8 and y == 4 and z == 1 then
+          b.focus_hold = not b.focus_hold
+          mc.mft_redraw(b[b.focus_hold and b.focus_pad or b.id],"all")
+        end
+      end
+      
+      if z == 1 and x <= 4 and y >= 4 and y <= 7 then
+        if b.focus_hold == false then
+          if not grid.alt then
+            selected[bank_64].x = (y-3)+(5*(bank_64-1))
+            selected[bank_64].y = 9-x
+            selected[bank_64].id = (4*(y-4))+x
+            b.id = selected[bank_64].id
+            which_bank = bank_64
+            pad_clipboard = nil
+            if b.quantize_press == 0 then
+              if arp[bank_64].enabled and grid_pat[bank_64].rec == 0 and not arp[bank_64].pause then
+                if arp[bank_64].down == 0 and params:string("arp_"..bank_64.."_hold_style") == "last pressed" then
+                  for j = #arp[bank_64].notes,1,-1 do
+                    table.remove(arp[bank_64].notes,j)
+                  end
+                end
+                arp[bank_64].time = b[b.id].arp_time
+                arps.momentary(bank_64, b.id, "on")
+                arp[bank_64].down = arp[bank_64].down + 1
+              else
+                if rytm.track[bank_64].k == 0 then
+                  cheat(bank_64, b.id)
+                end
+                grid_pattern_watch(bank_64)
+              end
+            else
+              table.insert(quantize_events[bank_64],selected[bank_64].id)
+            end
+          else
+            local released_pad = (4*(y-4))+x
+            arps.momentary(i, released_pad, "off")
+          end
+        else
+          if not grid.alt then
+            b.focus_pad = (4*(y-4))+x
+            mc.mft_redraw(b[b.focus_pad],"all")
+          elseif grid.alt then
+            if not pad_clipboard then
+              pad_clipboard = {}
+              b.focus_pad = (4*(y-4))+x
+              pad_copy(pad_clipboard, b[b.focus_pad])
+            else
+              b.focus_pad = (4*(y-4))+x
+              pad_copy(b[b.focus_pad], pad_clipboard)
+              pad_clipboard = nil
+            end
+          end
+        end
+        if menu ~= 1 then screen_dirty = true end
+      elseif z == 0 and x <= 4 and y >= 4 and y <= 7 then
+        if not b.focus_hold then
+          local released_pad = (4*(y-4))+x
+          if b[released_pad].play_mode == "momentary" then
+            softcut.rate(bank_64+1,0)
+          end
+          if (arp[bank_64].enabled and not arp[bank_64].hold) or (menu == 9 and not arp[bank_64].hold) then
+            arps.momentary(bank_64, released_pad, "off")
+            arp[bank_64].down = arp[bank_64].down - 1
+          elseif (arp[bank_64].enabled and arp[bank_64].hold and not arp[bank_64].pause) or (menu == 9 and arp[bank_64].hold and not arp[bank_64].pause) then
+            arp[bank_64].down = arp[bank_64].down - 1
+          end
+        end
+      end
+      
+      -- zilchmo 3+4 handling
+      -- if x == 4 or x == 5 or x == 9 or x == 10 or x == 14 or x == 15 then
+      if y == 6 or y == 7 or y == 8 then
+        if ((y == 6 and x >=7) or (y == 7 and x >= 6) or (y == 8 and x >= 5)) then
+          local zilch_id = (y == 8 and 4 or (y == 7 and 3 or 2))
+          local zmap = zilches[zilch_id]
+          local k1 = bank_64
+          local k2 = (zilch_id == 3 and x-5 or (zilch_id == 4 and x-4 or x-6))
+          if z == 1 then
+            zmap[k1][k2] = true
+            zmap[k1].held = zmap[k1].held + 1
+            zilch_leds[zilch_id][k1][k2] = 1
+            grid_dirty = true
+          elseif z == 0 then
+            if zmap[k1].held > 0 then
+              local coll = {}
+              for j = 1,4 do
+                if zmap[k1][j] == true then
+                  table.insert(coll,j)
+                end
+              end
+              coll.con = table.concat(coll)
+              local previous_rate = bank[k1][bank[k1].id].rate
+              rightangleslice.init(zilch_id,k1,coll.con)
+              if zilch_id == 4 then
+                record_zilchmo_4(previous_rate,k1,4,coll.con)
+              end
+              for j = 1,4 do
+                zmap[k1][j] = false
+              end
+            end
+            zmap[k1].held = 0
+            zilch_leds[zilch_id][k1][k2] = 0
+            grid_dirty = true
+            if menu ~= 1 then screen_dirty = true end
+          end
+        end
+      end
+
+      if z == 0 and x == 8 and y == 5 then
+        local i = bank_64
+        if grid_pat[i].quantize == 0 then -- still relevant
+          if bank[i].alt_lock and not grid.alt then
+            if grid_pat[i].play == 1 then
+              grid_pat[i].overdub = grid_pat[i].overdub == 0 and 1 or 0
+            end
+          else
+            if grid.alt then -- still relevant
+              grid_pat[i]:rec_stop()
+              grid_pat[i]:stop()
+              --grid_pat[i].external_start = 0
+              grid_pat[i].tightened_start = 0
+              grid_pat[i]:clear()
+              pattern_saver[i].load_slot = 0
+            elseif grid_pat[i].rec == 1 then -- still relevant
+              grid_pat[i]:rec_stop()
+              midi_clock_linearize(i)
+              if grid_pat[i].auto_snap == 1 then
+                print("auto-snap")
+                snap_to_bars(i,how_many_bars(i))
+              end
+              if grid_pat[i].mode ~= "quantized" then
+                --grid_pat[i]:start()
+                start_pattern(grid_pat[i])
+              --TODO: CONFIRM THIS IS OK...
+              elseif grid_pat[i].mode == "quantized" then
+                start_pattern(grid_pat[i])
+              end
+              grid_pat[i].loop = 1
+            elseif grid_pat[i].count == 0 then
+              if grid_pat[i].playmode ~= 2 then
+                grid_pat[i]:rec_start()
+              --new!
+              else
+                grid_pat[i].rec_clock = clock.run(synced_record_start,grid_pat[i],i)
+              end
+              --/new!
+            elseif grid_pat[i].play == 1 then
+              --grid_pat[i]:stop()
+              stop_pattern(grid_pat[i])
+            else
+              start_pattern(grid_pat[i])
+            end
+          end
+        else
+          if grid.alt then
+            grid_pat[i]:rec_stop()
+            grid_pat[i]:stop()
+            grid_pat[i].tightened_start = 0
+            grid_pat[i]:clear()
+            pattern_saver[i].load_slot = 0
+          else
+            --table.insert(grid_pat_quantize_events[i],i)
+            better_grid_pat_q_clock(i)
+          end
+        end
+      end
+      
+      if x == 5 and y == 6 and z == 1 then
+        grid_actions.toggle_pad_loop(bank_64)
+      end
+      
+      if x == 1 and y == 8 then
+        grid.alt = z == 1 and true or false
+        arc.alt = z
+        if menu ~= 1 then screen_dirty = true end
+      end
+      
+      if x == 5 or x == 6 or x == 7 then
+        if y == 4 then
+          local which_pad = nil
+          local current = bank_64
+          if z == 1 then
+            if not bank[current].alt_lock and not grid.alt then
+              if bank[current].focus_hold == false then
+                jump_clip(current, bank[current].id, x-4)
+              else
+                jump_clip(current, bank[current].focus_pad, x-4)
+              end
+            elseif bank[current].alt_lock or grid.alt then
+              for j = 1,16 do
+                jump_clip(current, j, x-4)
+              end
+            end
+          end
+          if z == 0 then
+            if menu ~= 1 then screen_dirty = true end
+            if bank[current].focus_hold == false then
+              if params:string("preview_clip_change") == "yes" or bank[current][bank[current].id].loop then
+                cheat(current,bank[current].id)
+              end
+            end
+          end
+        end
+      end
+
+      if (y == 5 and (x == 5 or x == 6)) and z == 1 then
+        local which_pad = nil
+        local current = bank_64
+        
+        if not bank[current].alt_lock and not grid.alt then
+          local target = bank[current].focus_hold == false and bank[current][bank[current].id] or bank[current][bank[current].focus_pad]
+          local old_mode = target.mode
+          target.mode = x-4
+          if old_mode ~= target.mode then
+            change_mode(target, old_mode)
+          end
+
+        elseif bank[current].alt_lock or grid.alt then
+          for k = 1,16 do
+            local old_mode = bank[current][k].mode
+            bank[current][k].mode = x-4
+            if old_mode ~= bank[current][k].mode then
+              change_mode(bank[current][k], old_mode)
+            end
+          end
+        end
+
+        if bank[current].focus_hold == false then
+          which_pad = bank[current].id
+        else
+          which_pad = bank[current].focus_pad
+        end
+
+
+        if bank[current].focus_hold == false then
+          if params:string("preview_clip_change") == "yes" then
+            cheat(current,bank[current].id)
+          end
+        end
+
+      end
+      
+      if y == 2 and x <= 3 and z == 1 then
+        if rec.focus ~= x then
+          rec.focus = x
+        else
+          toggle_buffer(x)
+          if grid.alt then
+            buff_flush()
+          end
+        end
+      end
+      
+      if y == 8 and x == 4 then
+        if not grid.alt then
+          bank[bank_64].alt_lock = z == 1 and true or false
+        else
+          if z == 1 then
+            bank[bank_64].alt_lock = not bank[bank_64].alt_lock
+          end
+        end
+      end
+      
+      if y == 6 and x == 6 and z == 1 then
+        if not bank[bank_64].alt_lock and not grid.alt then
+          grid_actions.arp_handler(bank_64)
+        else
+          grid_actions.kill_arp(bank_64)
+        end
+      end
+
+      if y == 7 and x == 5 and z == 1 then
+        local i = bank_64
+        if bank[i].alt_lock or grid.alt then
+          if not bank[i].focus_hold then
+            for j = 1,16 do
+              bank[i][j].rate = 1
+              if bank[i][j].fifth == true then
+                bank[i][j].fifth = false
+              end
+            end
+            softcut.rate(i+1,1*bank[i][bank[i].id].offset)
+          else
+            bank[i][bank[i].focus_pad].crow_pad_execute = (bank[i][bank[i].focus_pad].crow_pad_execute + 1)%2
+            for j = 1,16 do
+              bank[i][j].crow_pad_execute = bank[i][bank[i].focus_pad].crow_pad_execute
+            end
+          end
+        else
+          if bank[i].focus_hold then
+            bank[i][bank[i].focus_pad].crow_pad_execute = (bank[i][bank[i].focus_pad].crow_pad_execute + 1)%2
+          end
+        end
+        screen_dirty = true
+      end
+
+      if y == 5 and x == 7 and z == 1 and (grid.alt or bank[bank_64].alt_lock) then
+        random_grid_pat(bank_64,3)
+      end
+
+      if x == 8 and y == 1 and z == 1 then
+        grid_page_64 = 1
+      end
+
+    elseif grid_page_64 == 1 then
+
+      if x == 3 or x == 6 then
+        if y <= 2 and z == 1 then
+          local changes = {"double", "halve", "sync"}
+          del.change_duration(x == 3 and 1 or 2, x == 3 and 2 or 1, changes[y])
+        elseif y == 3 and z == 1 then
+          del.quick_action(x == 3 and 1 or 2, "reverse")
+        elseif y >= 4 and y <= 8 then
+          if z == 1 then
+            del.set_value(x == 3 and 1 or 2, math.abs(3-y), "level")
+          end
+        -- elseif y == 9 then
+        --   del.quick_action(x == 3 and 1 or 2,"level_mute",z)
+        end
+      elseif x == 4 or x == 5 then
+        if y >= 4 and y <= 8 then
+          if z == 1 then
+            del.set_value(x == 4 and 1 or 2, math.abs(3-y), "feedback")
+          end
+        elseif y == 1 and z == 1 then
+          del.change_rate(x == 4 and 1 or 2, "double")
+        elseif y == 2 and z == 1 then
+          del.change_rate(x == 4 and 1 or 2, "halve")
+        elseif y == 3 then
+          del.change_rate(x == 4 and 1 or 2,z == 1 and "wobble" or "restore")
+        -- elseif y == 9 then
+        --   if grid.alt then
+        --     del.quick_action(6-y, "clear")
+        --   end
+        --   del.quick_action(6-y,"feedback_mute",z)
+        end
+      elseif x == 1 or x == 8 then
+
+      elseif x == 2 or x == 7 then
+        if y == 8 then
+          del.quick_action(x == 2 and 1 or 2,"feedback_mute",z)
+        elseif y == 7 then
+          del.quick_action(x == 2 and 1 or 2,"level_mute",z)
+        elseif (y == 1 or y == 2 or y == 3) and z == 1 then
+          delay_grid.bank = y
+          local current_level = x == 2 and bank[delay_grid.bank][bank[delay_grid.bank].id].left_delay_level or bank[delay_grid.bank][bank[delay_grid.bank].id].right_delay_level
+          del.set_value(x == 2 and 1 or 2, current_level > 0 and 5 or 1,"send all")
+        elseif y == 4 and z == 1 then
+          params:set("delay "..(x == 2 and "L:" or "R:").." external input", params:get("delay "..(x == 2 and "L:" or "R:").." external input") > 0 and 0 or 1)
+        end
+        -- if x >= 10 and x <=14 then
+        --   if z == 1 then
+        --     del.set_value(y == 8 and 1 or 2,x-9,grid.alt == true and "send all" or "send")
+        --   end
+        -- elseif x == 15 then
+        --   del.quick_action(y == 8 and 1 or 2,"send_mute",z)
+        -- end
+      end
+
+      if x == 1 or x == 8 then
+        if y >= 3 and y <= 7 then
+          if z == 1 then
+            local bundle = (y-2)
+            local target = x == 1 and 1 or 2
+            local saved_already = delay_bundle[target][bundle].saved
+            if not saved_already then
+              delay[target].saver_active = true
+              clock.run(del.build_bundle,target,bundle)
+            elseif saved_already then
+              -- if grid.alt_delay then
+              if grid.alt then
+                del.clear_bundle(target,bundle)
+              else
+                del.restore_bundle(target,bundle)
+                delay[target].selected_bundle = bundle
+              end
+            end
+          elseif z == 0 then
+            delay[x<=2 and 1 or 2].saver_active = false
+          end
+        end
+      end
+
+      if x == 1 and y == 8 then
+        grid.alt = z == 1 and true or false
+      end
+
+      if x == 8 and y == 1 and z == 1 then
+        grid_page_64 = 0
+      end
+
+    end
+    grid_dirty = true
+  end
 end
 
 function grid_actions.arp_handler(i)

--- a/lib/main_menu.lua
+++ b/lib/main_menu.lua
@@ -63,17 +63,23 @@ function main_menu.init()
     , page.loops.frame == 2 and 3 or 15
     }
 
-    if page.loops.frame == 1 then
+    if page.loops.frame == 1 or (page.loops.frame == 2 and page.loops.sel == 5) then
     
-      local header = {"a","b","c","L"}
-      for i = 1,4 do
-        screen.level(page.loops.sel == i and screen_levels[4] or 3)
-        screen.move(60+(i*15),10)
-        screen.text_right(header[i])
+      if page.loops.frame == 2 and page.loops.sel == 5 and key1_hold then
+        -- screen.move(50+(5*15),13)
+        -- screen.level(15)
+        -- screen.text_right("E1: cycle")
+      else
+        local header = {"a","b","c","L","#"}
+        for i = 1,#header do
+          screen.level(page.loops.sel == i and screen_levels[4] or 3)
+          screen.move(50+(i*15),10)
+          screen.text_right(header[i])
+        end
+        screen.level(page.loops.sel == page.loops.sel and screen_levels[4] or 3)
+        screen.move(50+(page.loops.sel*15),13)
+        screen.text_right("_")
       end
-      screen.level(page.loops.sel == page.loops.sel and screen_levels[4] or 3)
-      screen.move(60+(page.loops.sel*15),13)
-      screen.text_right("_")
     
     elseif page.loops.frame == 2 then
 
@@ -106,11 +112,21 @@ function main_menu.init()
       local pad;
       if bank[page.loops.sel].focus_hold then
         pad = bank[page.loops.sel][bank[page.loops.sel].focus_pad]
-      elseif grid_pat[page.loops.sel].play == 0 and midi_pat[page.loops.sel].play == 0 and not arp[page.loops.sel].playing and rytm.track[page.loops.sel].k == 0 then
+      elseif page.loops.frame == 1 then
         pad = bank[page.loops.sel][bank[page.loops.sel].id]
-      else
-        pad = bank[page.loops.sel][bank[page.loops.sel].focus_pad]
+      elseif page.loops.frame == 2 then
+        if grid_pat[page.loops.sel].play == 0 and midi_pat[page.loops.sel].play == 0 and not arp[page.loops.sel].playing and rytm.track[page.loops.sel].k == 0 then
+          pad = bank[page.loops.sel][bank[page.loops.sel].id]
+        else
+          pad = bank[page.loops.sel][bank[page.loops.sel].focus_pad]
+        end
       end
+
+      -- elseif grid_pat[page.loops.sel].play == 0 and midi_pat[page.loops.sel].play == 0 and not arp[page.loops.sel].playing and rytm.track[page.loops.sel].k == 0 then
+      --   pad = bank[page.loops.sel][bank[page.loops.sel].id]
+      -- else
+      --   pad = bank[page.loops.sel][bank[page.loops.sel].focus_pad]
+      -- end
 
       -- local pad = bank[page.loops.sel].focus_hold and bank[page.loops.sel][bank[page.loops.sel].focus_pad] or bank[page.loops.sel][bank[page.loops.sel].id]
       
@@ -143,11 +159,22 @@ function main_menu.init()
         local which_pad;
         if bank[page.loops.sel].focus_hold then
           which_pad = bank[page.loops.sel].focus_pad
-        elseif grid_pat[page.loops.sel].play == 0 and midi_pat[page.loops.sel].play == 0 and not arp[page.loops.sel].playing and rytm.track[page.loops.sel].k == 0 then
+        elseif page.loops.frame == 1 then
           which_pad = bank[page.loops.sel].id
-        else
-          which_pad = bank[page.loops.sel].focus_pad
+        elseif page.loops.frame == 2 then
+          if grid_pat[page.loops.sel].play == 0 and midi_pat[page.loops.sel].play == 0 and not arp[page.loops.sel].playing and rytm.track[page.loops.sel].k == 0 then
+            which_pad = bank[page.loops.sel].id
+          else
+            which_pad = bank[page.loops.sel].focus_pad
+          end
         end
+
+        -- elseif grid_pat[page.loops.sel].play == 0 and midi_pat[page.loops.sel].play == 0 and not arp[page.loops.sel].playing and rytm.track[page.loops.sel].k == 0 then
+        --   which_pad = bank[page.loops.sel].id
+        -- else
+        --   which_pad = bank[page.loops.sel].focus_pad
+        -- end
+
         if not grid.alt then
           local loops_to_screen_options = {"a", "b", "c"}
           screen.text(loops_to_screen_options[page.loops.sel]..""..which_pad)
@@ -157,7 +184,23 @@ function main_menu.init()
             screen.text(loops_to_screen_options[page.loops.sel]..""..bank[page.loops.sel].id)
             screen.level(screen_levels[1])
           end
-          screen.move(3,30)
+          if (bank[page.loops.sel].focus_hold) or (page.loops.frame == 2 and (grid_pat[page.loops.sel].play == 1 or midi_pat[page.loops.sel].play == 1 or arp[page.loops.sel].playing or rytm.track[page.loops.sel].k ~= 0)) then
+            -- draw lock
+            screen.level(screen_levels[1])
+            for j = 1,6 do
+              for k = 5,9 do
+                screen.pixel(j,k+15)
+              end
+            end
+            screen.pixel(2,19)
+            screen.pixel(2,18)
+            screen.pixel(3,17)
+            screen.pixel(4,17)
+            screen.pixel(5,18)
+            screen.pixel(5,19)
+            screen.fill()
+          end
+          screen.move(3,33)
           screen.text_center(bank[page.loops.sel][which_pad].loop == false and "" or "∞")
         else
           local loops_to_screen_options = {"(a)","(b)","(c)"}
@@ -341,12 +384,14 @@ function main_menu.init()
           screen.line_rel(0,40)
           screen.stroke()
 
-          local current_to_screen = util.linlin(min,max,15,120,poll_position_new[1])
-          screen.level(screen_levels[3])
-          screen.move(current_to_screen,22)
-          screen.line_rel(0,25)
-          screen.text(rec[rec.focus].state == 1 and ">" or "")
-          screen.stroke()
+          if poll_position_new[1] >= rec[rec.focus].start_point and poll_position_new[1] <= rec[rec.focus].end_point then
+            local current_to_screen = util.linlin(min,max,15,120,poll_position_new[1])
+            screen.level(screen_levels[3])
+            screen.move(current_to_screen,22)
+            screen.line_rel(0,25)
+            screen.text(rec[rec.focus].state == 1 and ">" or "")
+            screen.stroke()
+          end
 
           local rate_options = {"8s","16s","32s"}
           local sets =
@@ -358,7 +403,7 @@ function main_menu.init()
             }
           , [2] =
             {
-              ("mode: "..(params:get("rec_loop") == 1 and "loop" or "shot"))
+              ("mode: "..(params:get("rec_loop_"..rec.focus) == 1 and "loop" or "shot"))
             , ("total: "..rate_options[params:get"live_buff_rate"])
             }
           , [3] =
@@ -405,6 +450,92 @@ function main_menu.init()
       
       end
 
+    elseif page.loops.sel == 5 then
+      for i = 1,4 do
+        local id;
+        local options;
+        screen.line_width(1)
+        if i < 4 then
+          if bank[i].focus_hold then
+            id = bank[i].focus_pad
+          elseif page.loops.frame == 1 then
+            id = bank[i].id
+          elseif page.loops.frame == 2 then
+            if grid_pat[i].play == 0 and midi_pat[i].play == 0 and not arp[i].playing and rytm.track[i].k == 0 then
+              id = bank[i].id
+            else
+              if key1_hold and page.loops.meta_sel == i then
+                id = bank[i].focus_pad
+              else
+                id = bank[i].id
+              end
+            end
+          end
+
+          local pad = bank[i][id]
+
+          local off = pad.mode == 1 and (((pad.clip-1)*8)+1) or clip[pad.clip].min
+          local display_end = pad.mode == 1 and (pad.end_point == 8.99 and 9 or pad.end_point) or pad.end_point
+
+
+          screen.level(page.loops.frame == 2 and (page.loops.meta_sel == i and 15 or 3) or 3)
+          screen.move(15,8+(i*14))
+          screen.line(115,8+(i*14))
+          screen.close()
+          screen.stroke()
+          local duration = bank[i][id].mode == 1 and 8 or clip[bank[i][id].clip].sample_length
+          local s_p = bank[i][id].mode == 1 and live[bank[i][id].clip].min or clip[bank[i][id].clip].min
+          local e_p = bank[i][id].mode == 1 and live[bank[i][id].clip].max or clip[bank[i][id].clip].max
+          local start_to_screen = util.linlin(s_p,e_p,15,115,bank[i][id].start_point)
+          screen.move(start_to_screen,21+(14*(i-1)))
+          screen.text("|")
+          local end_to_screen = util.linlin(s_p,e_p,15,115,bank[i][id].end_point)
+          screen.move(end_to_screen,27+(14*(i-1)))
+          screen.text("|")
+          if bank[i].focus_hold == false or bank[i].id == bank[i].focus_pad then
+            local current_to_screen = util.linlin(s_p,e_p,15,115,poll_position_new[i+1])
+            screen.move(current_to_screen,24+(14*(i-1)))
+            screen.text("|")
+          end
+
+        elseif i == 4 then
+          id = rec.focus
+          local off = ((id-1)*8)+1
+          local mults = {1,2,4}
+          local mult = mults[params:get("live_buff_rate")]
+
+
+        end
+
+        screen.move(0,8+(i*14))
+        screen.level(page.loops.meta_sel == i and screen_levels[1] or 3)
+        local loops_to_screen_options = {"a", "b", "c", "L"}
+        screen.text(loops_to_screen_options[i]..""..id)
+
+        if i < 4 then
+          if (bank[i].focus_hold) or (page.loops.frame == 2 and key1_hold and page.loops.meta_sel == i and (grid_pat[i].play == 1 or midi_pat[i].play == 1 or arp[i].playing or rytm.track[i].k ~= 0)) then
+            -- draw lock
+            screen.level(page.loops.meta_sel == i and 15 or 3)
+            for j = 120,125 do
+              for k = 5,9 do
+                screen.pixel(j,k+(i*14))
+              end
+            end
+            screen.pixel(121,4+(i*14))
+            screen.pixel(121,3+(i*14))
+            screen.pixel(122,2+(i*14))
+            screen.pixel(123,2+(i*14))
+            screen.pixel(124,4+(i*14))
+            screen.pixel(124,3+(i*14))
+            screen.fill()
+          end
+        end
+        -- screen.move(27,8+(i*14))
+        -- screen.text(options[1])
+        -- screen.move(67,8+(i*14))
+        -- screen.text(options[2])
+
+      end
     end
     
   elseif menu == 3 then

--- a/lib/midicheat.lua
+++ b/lib/midicheat.lua
@@ -104,6 +104,23 @@ function mc.enc_redraw(target)
   midi_dev[params:get("midi_enc_control_device")]:cc(4,level_to_cc,params:get("bank_"..target.bank_id.."_midi_enc_channel"))
 end
 
+function mc.params_redraw(target)
+  local duration = target.mode == 1 and 8 or clip[target.clip].sample_length
+  local min = target.mode == 1 and live[target.clip].min or clip[target.clip].min
+  local max = target.mode == 1 and live[target.clip].max or clip[target.clip].max
+  local start_to_cc = util.round(util.linlin(min,max,0,127,target.start_point))
+  params:set("current pad "..tonumber(string.format("%.0f",target.bank_id)),target.pad_id,"true")
+  params:set("start point "..tonumber(string.format("%.0f",target.bank_id)),start_to_cc,"true")
+  local end_to_cc = util.round(util.linlin(min,max,0,127,target.end_point))
+  params:set("end point "..tonumber(string.format("%.0f",target.bank_id)),end_to_cc,"true")
+  local pad_level_to_cc = util.round(util.linlin(0,2,0,127,target.level))
+  params:set("level "..tonumber(string.format("%.0f",target.bank_id)),pad_level_to_cc,"true")
+  local bank_level_to_cc = util.round(util.linlin(0,2,0,127,bank[target.bank_id].global_level))
+  params:set("bank level "..tonumber(string.format("%.0f",target.bank_id)),bank_level_to_cc,"true")
+  params:set("pan "..tonumber(string.format("%.0f",target.bank_id)),target.pan,"true")
+  local offset_to_cc = util.round(util.linlin(-1,1,0,127,(math.log(target.offset)/math.log(0.5))*-12))
+end
+
 function mc.mft_redraw(target,parameter)
   -- TODO: these need to redraw on the right target.bank_id CCs...
   -- TODO: when the bank is changed on MFT, redraw these

--- a/lib/start_up.lua
+++ b/lib/start_up.lua
@@ -70,7 +70,7 @@ function start_up.init()
   
   --params:add_separator()
   
-  params:add_group("loops + buffers", 22)
+  params:add_group("loops + buffers", 23)
 
   params:add_separator("clips")
   
@@ -130,6 +130,7 @@ function start_up.init()
   end
 
   params:add_option("one_shot_clock_div","--> 1-shot sync",{"next beat","next bar","free"},1)
+  params:add_control("one_shot_latency_offset","--> latency offset",controlspec.new(0,1,'lin',0.01,0,'s'))
 
   params:add_option("rec_loop_enc_resolution", "rec loop enc resolution", {"0.1","0.01","1/16","1/8","1/4","1/2","1 bar"}, 1)
   params:set_action("rec_loop_enc_resolution", function(x)
@@ -144,9 +145,14 @@ function start_up.init()
     }
     rec_loop_enc_resolution = resolutions[x]
     if x > 2 then
-      rec[rec.focus].start_point = 1+(8*(rec.focus-1))
+      -- rec[rec.focus].start_point = 1+(8*(rec.focus-1))
+      -- local lbr = {1,2,4}
+      -- rec[rec.focus].end_point = (1+(8*(rec.focus-1) + (1/rec_loop_enc_resolution))/lbr[params:get("live_buff_rate")])
       local lbr = {1,2,4}
-      rec[rec.focus].end_point = (1+(8*(rec.focus-1) + (1/rec_loop_enc_resolution))/lbr[params:get("live_buff_rate")])
+      for i = 1,3 do
+        rec[i].start_point = 1+(8*(i-1))
+        rec[i].end_point = (1+(8*(i-1) + (1/rec_loop_enc_resolution))/lbr[params:get("live_buff_rate")])
+      end
       softcut.loop_start(1,rec[rec.focus].start_point)
       softcut.loop_end(1,rec[rec.focus].end_point)
     end

--- a/lib/start_up.lua
+++ b/lib/start_up.lua
@@ -70,7 +70,7 @@ function start_up.init()
   
   --params:add_separator()
   
-  params:add_group("loops + buffers", 20)
+  params:add_group("loops + buffers", 22)
 
   params:add_separator("clips")
   
@@ -86,24 +86,48 @@ function start_up.init()
   params:add_separator("live")
 
 
-  params:add_option("rec_loop", "live rec behavior", {"loop","1-shot"}, 1)
-  params:set_action("rec_loop",
-    function(x)
-      rec[rec.focus].loop = 2-x
-      softcut.loop(1,rec[rec.focus].loop)
-      softcut.position(1,rec[rec.focus].start_point)
-      -- rec[rec.focus].state = 0
-      softcut.rec_level(1,rec[rec.focus].state)
-      if rec[rec.focus].state == 1 then
-        if x == 2 then
-          --rec_state_watcher:start()
-          softcut.pre_level(1,params:get("live_rec_feedback"))
-        elseif x == 1 then
-          softcut.pre_level(1,params:get("live_rec_feedback"))
+  -- params:add_option("rec_loop", "live rec behavior", {"loop","1-shot"}, 1)
+  -- params:set_action("rec_loop",
+  --   function(x)
+  --     rec[rec.focus].loop = 2-x
+  --     softcut.loop(1,rec[rec.focus].loop)
+  --     softcut.position(1,rec[rec.focus].start_point)
+  --     -- rec[rec.focus].state = 0
+  --     softcut.rec_level(1,rec[rec.focus].state)
+  --     if rec[rec.focus].state == 1 then
+  --       if x == 2 then
+  --         --rec_state_watcher:start()
+  --         softcut.pre_level(1,params:get("live_rec_feedback"))
+  --       elseif x == 1 then
+  --         softcut.pre_level(1,params:get("live_rec_feedback"))
+  --       end
+  --     end
+  --   end
+  -- )
+
+  for i = 1,3 do
+    params:add_option("rec_loop_"..i, "live "..i.." rec behavior", {"loop","1-shot"}, 1)
+    params:set_action("rec_loop_"..i,
+      function(x)
+        rec[i].loop = 2-x
+        if rec[i].loop == 0 then rec.stopped = true end
+        if rec.focus == i then
+          softcut.loop(1,rec[rec.focus].loop)
+          softcut.position(1,rec[rec.focus].start_point)
+          -- rec[rec.focus].state = 0
+          softcut.rec_level(1,rec[rec.focus].state)
+          if rec[rec.focus].state == 1 then
+            if x == 2 then
+              --rec_state_watcher:start()
+              softcut.pre_level(1,params:get("live_rec_feedback"))
+            elseif x == 1 then
+              softcut.pre_level(1,params:get("live_rec_feedback"))
+            end
+          end
         end
       end
-    end
-  )
+    )
+  end
 
   params:add_option("one_shot_clock_div","--> 1-shot sync",{"next beat","next bar","free"},1)
 
@@ -266,7 +290,7 @@ function start_up.init()
   )
   
   params:add_group("manual control",34)
-  params:hide("manual control")
+  -- params:hide("manual control")
 
   params:add_separator("arc encoders")
   for i = 1,3 do

--- a/lib/zilchmos.lua
+++ b/lib/zilchmos.lua
@@ -112,10 +112,11 @@ function zilchmos.start_end_default( pad )
   local duration;
   if pad.mode == 1 then
     --slice within bounds
-    duration = rec[rec.focus].end_point-rec[rec.focus].start_point
-    local s_p = rec[rec.focus].start_point+(8*(pad.clip-1))
-    -- pad.start_point = (rec[rec.focus].start_point+((duration/16) * (pad.pad_id-1)))+((pad.clip-1)*8)
-    -- pad.end_point = (rec[rec.focus].start_point+((duration/16) * (pad.pad_id)))+((pad.clip-1)*8)
+    -- duration = rec[rec.focus].end_point-rec[rec.focus].start_point
+    -- local s_p = rec[rec.focus].start_point+(8*(pad.clip-1))
+    duration = rec[pad.clip].end_point-rec[pad.clip].start_point
+    -- local s_p = rec[pad.clip].start_point+(8*(pad.clip-1))
+    local s_p = rec[pad.clip].start_point
     pad.start_point = (s_p+(duration/16) * (pad.pad_id-1))
     pad.end_point = (s_p+((duration/16) * (pad.pad_id)))
   else


### PR DESCRIPTION
additions:

- 64 grid support (see PARAMS > GRID): main performance and delay pages! more to come.
- 1-shot Live rec latency offset: if you're recording into cheat codes from another computer's DAW, you'll likely see some latency in 1-shot mode. this is expected, so the `latency offset` parameter allows you to compensate for this in 10ms increments, up to 1 second. ymmv, but an easy way to determine a good value to is record in 1-shot mode without this compensation and see how many 0.01s increments it takes to align an auto-chopped pad to the start of the recorded sample. match the latency compensation to this number of increments and you'll be set for the rest of the session!
- brought back `manual control` parameters for folks wishing to map a static slider to current pad's start/end points
- laid the foundation for a `#` submenu to the `[loops]` menu, not accessible in this update tho :)

fixes:

- arc window parameter now calculate correctly
- Live rec behaviors (loop or 1-shot) are unique per Live segment
- changing rec loop encoder resolution snaps all segments to appropriate values
- auto-slice zilchmo gesture now checks for pads' segment assignment and auto-chops pads appropriately to the segment's start and end points (previously, was just checking with the current rec focus start/end points)
- more fluid buffer jumping