### PR TITLE
210221: quick bug fixes

### DIFF
--- a/cheat_codes_2.lua
+++ b/cheat_codes_2.lua
@@ -2812,6 +2812,7 @@ function cheat(b,i)
       if pad.envelope_mode == 3 then env_counter[b].stage = "rising" end
     end
     if pad.level > 0.05 then
+    -- if (pad.envelope_time/(pad.level/0.05)) ~= inf then
       env_counter[b].time = (pad.envelope_time/(pad.level/0.05)) -- buggy, what am i trying to do here??
     end
     env_counter[b]:start()
@@ -3049,7 +3050,8 @@ function rising_envelope(i)
       env_counter[i].stage = "falling"
       softcut.level_slew_time(i+1,0.05)
       env_counter[i].butt = bank[i][bank[i].id].level
-      if bank[i][bank[i].id].level > 0 then
+      if bank[i][bank[i].id].level > 0.05 then
+      -- if bank[i][bank[i].id].envelope_time/(bank[i][bank[i].id].level/0.05) ~= inf then
         env_counter[i].time = (bank[i][bank[i].id].envelope_time/(bank[i][bank[i].id].level/0.05))
       end
       env_counter[i]:start()

--- a/cheat_codes_2.lua
+++ b/cheat_codes_2.lua
@@ -3080,9 +3080,9 @@ function easing_slew(i)
   slew_counter[i].slewedVal = slew_counter[i].ease(slew_counter[i].current,slew_counter[i].beginVal,slew_counter[i].change,slew_counter[i].duration)
   slew_counter[i].slewedQ = slew_counter[i].ease(slew_counter[i].current,slew_counter[i].beginQ,slew_counter[i].changeQ,slew_counter[i].duration)
   slew_counter[i].current = slew_counter[i].current + 0.01
-  if grid_alt then
+  if grid_alt and all_loaded then
     try_tilt_process(i,bank[i].id,slew_counter[i].slewedVal,slew_counter[i].slewedQ)
-  else
+  elseif all_loaded then
     for j = 1,16 do
       try_tilt_process(i,j,slew_counter[i].slewedVal,slew_counter[i].slewedQ)
     end

--- a/cheat_codes_2.lua
+++ b/cheat_codes_2.lua
@@ -18,19 +18,18 @@ end
 
 local grid = util.file_exists(_path.code.."midigrid") and include "midigrid/lib/midigrid" or grid
 
--- if util.file_exists(_path.code.."timber") then
---   Timber = include 'timber/lib/timber_engine'
---   engine.name = "Timber"
---   Timber.add_params()
---   local NUM_SAMPLES = 16
---   for i = 1,16 do
---     Timber.add_sample_params(i, true, false)
---   end
+-- if util.file_exists(_path.code.."mx.samples") then
+--   mxsamples = include 'mx.samples/lib/mx.samples'
+--   engine.name = "MxSamples"
+--   mxcc = mxsamples:new()
+--   print("available instruments: ")
+--   tab.print(mxcc:list_instruments())
 -- end
 
 local pattern_time = include 'lib/cc_pattern_time'
 MU = require "musicutil"
 UI = require "ui"
+lattice = require "lattice"
 fileselect = require 'fileselect'
 textentry = require 'textentry'
 main_menu = include 'lib/main_menu'
@@ -47,7 +46,6 @@ rytm = include 'lib/euclid'
 mc = include 'lib/midicheat'
 sharer = include 'lib/sharer'
 macros = include 'lib/macros'
-lattice = require("lattice")
 transport = include 'lib/transport'
 math.randomseed(os.time())
 variable_fade_time = 0.01
@@ -2813,7 +2811,9 @@ function cheat(b,i)
       env_counter[b].r_del_butt = 0
       if pad.envelope_mode == 3 then env_counter[b].stage = "rising" end
     end
-    env_counter[b].time = (pad.envelope_time/(pad.level/0.05))
+    if pad.level > 0.05 then
+      env_counter[b].time = (pad.envelope_time/(pad.level/0.05)) -- buggy, what am i trying to do here??
+    end
     env_counter[b]:start()
   elseif not pad.enveloped and not pad.pause then
     softcut.level_slew_time(b+1,0.1)
@@ -2965,7 +2965,7 @@ function falling_envelope(i)
   else
     env_counter[i].butt = 0
   end
-  if env_counter[i].butt > 0 then
+  if env_counter[i].butt > 0 and bank[i][bank[i].id].level > 0 then
     softcut.level_slew_time(i+1,0.05)
     softcut.level(i+1,env_counter[i].butt*bank[i].global_level)
     -- softcut.level_cut_cut(i+1,5,(env_counter[i].butt*bank[i].global_level)*bank[i][bank[i].id].left_delay_level)
@@ -3049,7 +3049,9 @@ function rising_envelope(i)
       env_counter[i].stage = "falling"
       softcut.level_slew_time(i+1,0.05)
       env_counter[i].butt = bank[i][bank[i].id].level
-      env_counter[i].time = (bank[i][bank[i].id].envelope_time/(bank[i][bank[i].id].level/0.05))
+      if bank[i][bank[i].id].level > 0 then
+        env_counter[i].time = (bank[i][bank[i].id].envelope_time/(bank[i][bank[i].id].level/0.05))
+      end
       env_counter[i]:start()
     end
     if bank[i][bank[i].id].envelope_loop == true then
@@ -3668,6 +3670,7 @@ function key(n,z)
         if page.loops.frame == 2 and key1_hold then
           if page.loops.sel == 4 then
             buff_flush()
+            print("press")
           elseif page.loops.sel < 4 then
             sync_clock_to_loop(bank[page.loops.sel][bank[page.loops.sel].id],"audio")
           elseif page.loops.sel == 5 then
@@ -3733,22 +3736,11 @@ function key(n,z)
       elseif menu == 2 then
         if page.loops.frame == 2 and key1_hold then
           if page.loops.sel == 4 then
-            buff_flush()
+            -- buff_flush()
+            -- print("release???")
           elseif page.loops.sel < 4 then
             sync_clock_to_loop(bank[page.loops.sel][bank[page.loops.sel].id],"audio")
           end
-        -- if key1_hold and page.loops_sel ~= 4 then
-        --   if page.loops_view[page.loops_sel] == 1 then
-        --     sync_clock_to_loop(bank[page.loops_sel][bank[page.loops_sel].id],"audio")
-        --   elseif page.loops_view[page.loops_sel] == 2 then
-        --     rightangleslice.init(4,id,'14')
-        --   end
-        -- elseif key1_hold and page.loops_sel == 4 then
-        --   buff_pause()
-        else
-          -- if page.loops.frame == 1 then
-          --   menu = 1
-          -- end
         end
       else
         menu = 1
@@ -5569,9 +5561,16 @@ function named_loadstate(path)
       if tab.load(_path.data .. "cheat_codes_2/collection-"..collection.."/rnd/"..i..".data") ~= nil then
         rnd[i] = tab.load(_path.data .. "cheat_codes_2/collection-"..collection.."/rnd/"..i..".data")
         for j = 1,#rnd[i] do
-          rnd[i][j].clock = nil
-          if rnd[i][j].playing then
-            rnd[i][j].clock = clock.run(rnd.advance, i, j)
+          -- rnd[i][j].clock = nil
+          -- if rnd[i][j].playing then
+          --   rnd[i][j].clock = clock.run(rnd.advance, i, j)
+          -- end
+          if rnd[i][j].lattice == nil then
+            rnd[i][j].lattice = rnd_lattice:new_pattern{
+              action = function() rnd.lattice_advance(i,j) end,
+              division = rnd[i][j].time/4,
+              enabled = true
+            }
           end
         end
       end

--- a/lib/arp_actions.lua
+++ b/lib/arp_actions.lua
@@ -4,6 +4,12 @@ arp = {}
 
 arp_clock = {}
 
+-- arp_lattice = lattice:new{
+--   auto = true,
+--   meter = 4,
+--   ppqn = 96
+-- }
+
 function arp_actions.init(target)
     arp[target] = {}
     arp[target].playing = false
@@ -19,7 +25,25 @@ function arp_actions.init(target)
     arp[target].down = 0
     arp[target].retrigger = true
     arp_clock[target] = clock.run(arp_actions.arpeggiate,target)
+    -- arp[target].lattice = arp_lattice:new_pattern{
+    --   action = function() arp_actions.lattice_advance(target) end,
+    --   division = arp[target].time/4,
+    --   enabled = arp[target].enabled
+    -- }
+    -- clock.run(function() clock.sync(4) arp_lattice:start() end)
 end
+
+-- function arp_actions.toggle_arp(target,enable)
+--   if enable then
+--     clock.run(function()
+--       arp[target].lattice.phase = 0
+--       clock.sync(arp[target].time)
+--       arp[target].lattice:start()
+--     end)
+--   else
+--     arp[target].lattice:stop()
+--   end
+-- end
 
 function arp_actions.find_index(tab,el)
     local rev = {}
@@ -70,32 +94,35 @@ function arp_actions.toggle(state,target)
   end
 end
 
-function arp_actions.iter(target)
-  -- if transport.is_running then
-  --   if #arp[target].notes > 0 then
-  --     if arp[target].pause == false then
-  --       if arp[target].mode == "fwd" then
-  --         arp_actions.forward(target)
-  --       elseif arp[target].mode == "bkwd" then
-  --         arp_actions.backward(target)
-  --       elseif arp[target].mode == "pend" then
-  --         arp_actions.pendulum(target)
-  --       elseif arp[target].mode == "rnd" then
-  --         arp_actions.random(target)
-  --       end
-  --       arp[target].playing = true
-  --       if target == 2 then print("arp: "..clock.get_beats()) end
-  --       arp_actions.cheat(target,arp[target].step)
-  --       grid_dirty = true
-  --     else
-  --       arp[target].playing = false
-  --     end
-  --   else
-  --     arp[target].playing = false
-  --   end
-  --   if menu ~= 1 then screen_dirty = true end
-  -- end
-end
+-- function arp_actions.lattice_advance(target)
+--   if target == 1 then
+--     print(clock.get_beats())
+--     if transport.is_running then
+--       if #arp[target].notes > 0 then
+--         if arp[target].pause == false then
+--           -- if arp[target].step == 1 then print("arp "..target, clock.get_beats()) end
+--           if menu ~= 1 then screen_dirty = true end
+--           if arp[target].mode == "fwd" then
+--             arp_actions.forward(target)
+--           elseif arp[target].mode == "bkwd" then
+--             arp_actions.backward(target)
+--           elseif arp[target].mode == "pend" then
+--             arp_actions.pendulum(target)
+--           elseif arp[target].mode == "rnd" then
+--             arp_actions.random(target)
+--           end
+--           arp[target].playing = true
+--           arp_actions.cheat(target,arp[target].step)
+--           grid_dirty = true
+--         else
+--           arp[target].playing = false
+--         end
+--       else
+--         arp[target].playing = false
+--       end
+--     end
+--   end
+-- end
 
 function arp_actions.arpeggiate(target)
   while true do

--- a/lib/encoder_actions.lua
+++ b/lib/encoder_actions.lua
@@ -824,6 +824,7 @@ function encoder_actions.init(n,d)
         bank[n][focused_pad].level = util.clamp(bank[n][focused_pad].level+d/10,0,2)
         if bank[n][focused_pad].enveloped and not bank[n][focused_pad].pause then
           if bank[n][focused_pad].level > 0.05 then
+          -- if bank[n][focused_pad].envelope_time/(bank[n][focused_pad].level/0.05) ~= inf then
             env_counter[n].time = (bank[n][focused_pad].envelope_time/(bank[n][focused_pad].level/0.05))
           end
         end
@@ -922,6 +923,7 @@ function encoder_actions.init(n,d)
         end
       end
       if bank[n][focused_pad].level > 0.05 then
+      -- if bank[n][focused_pad].envelope_time/(bank[n][focused_pad].level/0.05) ~= inf then
         env_counter[n].time = (bank[n][focused_pad].envelope_time/(bank[n][focused_pad].level/0.05))
       end
     end

--- a/lib/encoder_actions.lua
+++ b/lib/encoder_actions.lua
@@ -734,10 +734,12 @@ function encoder_actions.init(n,d)
           end
         elseif page.rnd_page_edit[page.rnd_page] == 3 then
           current.num = util.clamp(current.num+d,1,32)
-          current.time = current.num / current.denom
+          -- current.time = current.num / current.denom
+          rnd.update_time(page.rnd_page,page.rnd_page_sel[page.rnd_page])
         elseif page.rnd_page_edit[page.rnd_page] == 4 then
           current.denom = util.clamp(current.denom+d,1,32)
-          current.time = current.num / current.denom
+          -- current.time = current.num / current.denom
+          rnd.update_time(page.rnd_page,page.rnd_page_sel[page.rnd_page])
         elseif page.rnd_page_edit[page.rnd_page] == 5 then
           if current.param == "pan" then
             current.pan_min = util.clamp(current.pan_min+d,-100,current.pan_max-1)
@@ -820,6 +822,11 @@ function encoder_actions.init(n,d)
         bank[n].global_level = util.clamp(bank[n].global_level+d/10,0,2)
       else
         bank[n][focused_pad].level = util.clamp(bank[n][focused_pad].level+d/10,0,2)
+        if bank[n][focused_pad].enveloped and not bank[n][focused_pad].pause then
+          if bank[n][focused_pad].level > 0.05 then
+            env_counter[n].time = (bank[n][focused_pad].envelope_time/(bank[n][focused_pad].level/0.05))
+          end
+        end
       end
       if bank[n][bank[n].id].envelope_mode == 2 or bank[n][bank[n].id].enveloped == false then
         if bank[n].focus_hold == false then
@@ -914,7 +921,9 @@ function encoder_actions.init(n,d)
           bank[n][focused_pad].envelope_time = util.linexp(0.05,60,0.05,60,bank[n][focused_pad].envelope_time)
         end
       end
-      env_counter[n].time = (bank[n][focused_pad].envelope_time/(bank[n][focused_pad].level/0.05))
+      if bank[n][focused_pad].level > 0.05 then
+        env_counter[n].time = (bank[n][focused_pad].envelope_time/(bank[n][focused_pad].level/0.05))
+      end
     end
   end
   if menu == 4 then

--- a/lib/midicheat.lua
+++ b/lib/midicheat.lua
@@ -518,7 +518,13 @@ function mc.pad_to_note_params()
     end)
     params:add_number(i.."_pad_to_wsyn_note_velocity", "w/syn velocity",0,127,60)
     mc.build_scale(i)
-    -- params:add_number(i.."_pad_to_midi_note_duration", "note length",1,16,1)
+    -- if mxcc ~= nil then
+    --   mxcc_available = mxcc:list_instruments()
+    -- else
+    --   mxcc_available = {}
+    -- end
+    -- table.insert(mxcc_available,1,"none")
+    -- params:add_option(i.."_pad_to_mxcc_note_enabled", "Mx voice",mxcc_available,1)
   end
 
   params:add_group("w/syn controls",10)
@@ -664,6 +670,12 @@ end
 --   print("this is 3")
 -- end
 
+local mx_dests ={
+  "steinway model b"
+, "cello"
+, "alto sax choir"
+}
+
 function mc.midi_note_from_pad(b,p)
   if params:string(b.."_pad_to_midi_note_enabled") == "yes" then
     if mc.get_midi("midi_notes",b,p) ~= "-" and mc.get_midi("midi_notes_velocities",b,p) ~= "-" and mc.get_midi("midi_notes_channels",b,p) ~= "-" then
@@ -678,6 +690,7 @@ function mc.midi_note_from_pad(b,p)
       table.insert(active_midi_notes[b], note_num)
       if midi_off[b] ~= nil then clock.cancel(midi_off[b]) end
       midi_off[b] = clock.run(mc.midi_note_from_pad_off,b,p)
+      -- mxcc:on({name = mx_dests[b],midi=note_num,velocity=vel})
     end
   end
   if mc.get_midi("midi_ccs",b,p) ~= "-" and mc.get_midi("midi_ccs_values",b,p) ~= "-" and mc.get_midi("midi_ccs_channels",b,p) ~= "-" then
@@ -734,6 +747,7 @@ end
 function mc.all_midi_notes_off(b)
   for _, a in pairs(active_midi_notes[b]) do
     midi_dev[params:get(b.."_pad_to_midi_note_destination")]:note_off(a, nil, params:get(b.."_pad_to_midi_note_channel"))
+    -- mxcc:off({name = mx_dests[b],midi=a})
   end
   active_midi_notes[b] = {}
 end

--- a/lib/rnd_actions.lua
+++ b/lib/rnd_actions.lua
@@ -144,6 +144,9 @@ function rnd.pan(t,i)
     bank[t][bank[t].id].pan = rand_pan
   end
   softcut.pan(t+1,rand_pan)
+  if menu == 4 then
+    screen_dirty = true
+  end
 end
 
 function rnd.rate(t,i)
@@ -198,6 +201,9 @@ function rnd.delay_send(t,i)
     softcut.level_cut_cut(t+1,6,(bank[t][bank[t].id].right_delay_level*bank[t][bank[t].id].level)*bank[t].global_level)
   end
   grid_dirty = true
+  if menu == 6 then
+    screen_dirty = true
+  end
 end
 
 function rnd.offset(t,i)


### PR DESCRIPTION
FIXED:
- `rnd`: now runs on its own lattice, which reduces the number of possibly active clocks by *a lot*. this should leave much room for other clocked processes, which leads to more overall stability.
- `levels`: an envelope on a silenced pad would cause infinity to be passed as a value to the envelope counter, resulting in computational overload. this has been fixed!
- `pan` and `delay` screens weren't being redrawn when `rnd` generated new values for them