### PR TITLE
modernize crow v3

### DIFF
--- a/cheat_codes_2.lua
+++ b/cheat_codes_2.lua
@@ -794,8 +794,7 @@ grid_alt = false
 grid_loop_mod = 0
 
 local function crow_flush()
-  crow.reset()
-  crow.clear()
+  norns.crow.init() -- clears & inits both crow & norns-support-of-crow
 end
 
 local function crow_init()
@@ -805,6 +804,15 @@ local function crow_init()
   end
   crow.input[2].mode("change",2,0.1,"rising")
   crow.input[2].change = buff_freeze
+end
+
+-- crow hotplug support
+norns.crow.add = function()
+  norns.crow.init()
+  crow_init()
+  if params:get("jf_toggle") == 2 then
+    crow.ii.jf.mode(1)
+  end
 end
 
 local function process_stream_1(v)
@@ -1030,11 +1038,12 @@ function init()
   for i = 1,4 do
     crow.output[i].action = "{to(5,0),to(0,0.05)}"
   end
-  crow.count = {}
-  crow.count_execute = {}
+  _crow = {}
+  _crow.count = {}
+  _crow.count_execute = {}
   for i = 1,3 do
-    crow.count[i] = 1
-    crow.count_execute[i] = 1
+    _crow.count[i] = 1
+    _crow.count_execute[i] = 1
   end
 
   screen.line_width(1)

--- a/lib/encoder_actions.lua
+++ b/lib/encoder_actions.lua
@@ -603,7 +603,7 @@ function encoder_actions.init(n,d)
             end
           end
         elseif page_line[pattern_page] == 8 and bank[pattern_page].crow_execute ~= 1 then
-          crow.count_execute[pattern_page] = util.clamp(crow.count_execute[pattern_page]+d,1,16)
+          _crow.count_execute[pattern_page] = util.clamp(_crow.count_execute[pattern_page]+d,1,16)
         elseif page_line[pattern_page] == 3 then
           params:delta("sync_clock_to_pattern_"..pattern_page,d)
         elseif page_line[pattern_page] == 4 then

--- a/lib/main_menu.lua
+++ b/lib/main_menu.lua
@@ -1099,7 +1099,7 @@ function main_menu.init()
             if bank[page_line].crow_execute ~= 1 then
               screen.move(97,40)
               screen.level(time_page[page_line] == 8 and 15 or 3)
-              screen.text("(/"..crow.count_execute[page_line]..")")
+              screen.text("(/".._crow.count_execute[page_line]..")")
             end
           end
         end

--- a/lib/midicheat.lua
+++ b/lib/midicheat.lua
@@ -537,7 +537,7 @@ function mc.pad_to_note_params()
     options = {"off", "on"},
     default = 2,
     action = function(val) 
-      crow.send("ii.wsyn.ar_mode(" .. (val - 1) .. ")") 
+      crow.ii.wsyn.ar_mode(val - 1) 
     end
   }
   params:add {
@@ -546,7 +546,7 @@ function mc.pad_to_note_params()
     name = "Curve",
     controlspec = controlspec.new(-5, 5, "lin", 0, 0, "v"),
     action = function(val) 
-      crow.send("ii.wsyn.curve(" .. val .. ")") 
+      crow.ii.wsyn.curve(val)
     end
   }
   params:add {
@@ -555,7 +555,7 @@ function mc.pad_to_note_params()
     name = "Ramp",
     controlspec = controlspec.new(-5, 5, "lin", 0, 0, "v"),
     action = function(val) 
-      crow.send("ii.wsyn.ramp(" .. val .. ")")
+      crow.ii.wsyn.ramp(val)
     end
   }
   params:add {
@@ -564,7 +564,7 @@ function mc.pad_to_note_params()
     name = "FM index",
     controlspec = controlspec.new(0, 5, "lin", 0, 0, "v"),
     action = function(val) 
-      crow.send("ii.wsyn.fm_index(" .. val .. ")")
+      crow.ii.wsyn.fm_index(val)
     end
   }
   params:add {
@@ -573,7 +573,7 @@ function mc.pad_to_note_params()
     name = "FM env",
     controlspec = controlspec.new(-5, 5, "lin", 0, 0, "v"),
     action = function(val) 
-      crow.send("ii.wsyn.fm_env(" .. val .. ")")
+      crow.ii.wsyn.fm_env(val)
     end
   }
   params:add {
@@ -582,7 +582,7 @@ function mc.pad_to_note_params()
     name = "FM ratio numerator",
     controlspec = controlspec.new(1, 20, "lin", 1, 2),
     action = function(val) 
-      crow.send("ii.wsyn.fm_ratio(" .. val .. "," .. params:get("w/fm den") .. ")")
+      crow.ii.wsyn.fm_ratio(val, params:get("w/fm den"))
     end
   }
   params:add {
@@ -591,7 +591,7 @@ function mc.pad_to_note_params()
     name = "FM ratio denominator",
     controlspec = controlspec.new(1, 20, "lin", 1, 1),
     action = function(val) 
-      crow.send("ii.wsyn.fm_ratio(" .. params:get("w/fm num") .. "," .. val .. ")")
+      crow.ii.wsyn.fm_ratio(params:get("w/fm num"), val)
     end
   }
   params:add {
@@ -600,7 +600,7 @@ function mc.pad_to_note_params()
     name = "LPG time",
     controlspec = controlspec.new(-5, 5, "lin", 0, 0, "v"),
     action = function(val) 
-      crow.send("ii.wsyn.lpg_time(" .. val .. ")")
+      crow.ii.wsyn.lpg_time(val)
     end
   }
   params:add {
@@ -609,7 +609,7 @@ function mc.pad_to_note_params()
     name = "LPG symmetry",
     controlspec = controlspec.new(-5, 5, "lin", 0, 0, "v"),
     action = function(val) 
-      crow.send("ii.wsyn.lpg_symmetry(" .. val .. ")")
+      crow.ii.wsyn.lpg_symmetry(val)
     end
   }
   params:add{
@@ -630,14 +630,14 @@ function mc.pad_to_note_params()
   }
 
   function wsyn_init()
-    crow.send("ii.wsyn.ar_mode(" .. (params:get("wsyn_ar_mode") - 1) .. ")") 
-    crow.send("ii.wsyn.curve(" .. params:get("w/curve") .. ")") 
-    crow.send("ii.wsyn.ramp(" .. params:get("w/ramp") .. ")") 
-    crow.send("ii.wsyn.fm_index(" .. params:get("w/fm index") .. ")") 
-    crow.send("ii.wsyn.fm_env(" .. params:get("w/fm env") .. ")")
-    crow.send("ii.wsyn.fm_ratio("..params:get("w/fm num")..","..params:get("w/fm den")..")")
-    crow.send("ii.wsyn.lpg_time(" .. params:get("w/lpg time") .. ")") 
-    crow.send("ii.wsyn.lpg_symmetry(" .. params:get("w/lpg symm") .. ")") 
+    crow.ii.wsyn.ar_mode(params:get("wsyn_ar_mode") - 1)
+    crow.ii.wsyn.curve(params:get("w/curve"))
+    crow.ii.wsyn.ramp(params:get("w/ramp"))
+    crow.ii.wsyn.fm_index(params:get("w/fm index"))
+    crow.ii.wsyn.fm_env(params:get("w/fm env"))
+    crow.ii.wsyn.fm_ratio(params:get("w/fm num"), params:get("w/fm den"))
+    crow.ii.wsyn.lpg_time(params:get("w/lpg time"))
+    crow.ii.wsyn.lpg_symmetry(params:get("w/lpg symm"))
   end
 
 end
@@ -729,12 +729,10 @@ function mc.midi_note_from_pad(b,p)
       local note_num = mc_notes[b][p] - 60
       local velocity = util.linlin(0,127,0,5,params:get(b.."_pad_to_wsyn_note_velocity"))
       if params:string(b.."_pad_to_wsyn_note_enabled") == "any" then
-        -- crow.ii.jf.play_note(note_num/12,velocity)
-        crow.send("ii.wsyn.play_note(" .. note_num/12 .. "," .. velocity .. ")")
+        crow.ii.wsyn.play_note(note_num/12,velocity)
       else
         local wsyn_chan = params:get(b.."_pad_to_wsyn_note_enabled") - 1
-        -- crow.ii.jf.play_voice(jf_chan,note_num/12,velocity)
-        crow.send("ii.wsyn.play_voice(" .. wsyn_chan .. "," .. note_num/12 .. "," .. velocity .. ")")
+        crow.ii.wsyn.play_voice(wsyn_chan,note_num/12,velocity)
       end
     end
   end


### PR DESCRIPTION
a quick once-over to try and get everything working well with crow v3.

* adds hot-plug crow support (including reactivating jf_mode(1) if appropriate)
* renames `crow.count` and `count_execute` into `_crow` namespace (this was broken by v3)
* simplifies crow-flush & ensures norns.crow is cleaned up too.

could use testing to specifically test:
* jf_mode(1) is correctly init'd
* hot-plug support re-enables crow & jf output
* wsyn params still work (they were cleaned up)