### PR TITLE
rev 230104: LTS10.1

### DIFF
--- a/lib/encoder_actions.lua
+++ b/lib/encoder_actions.lua
@@ -587,7 +587,13 @@ function encoder_actions.init(n,d)
       local page_line = page.time_page_sel
       local pattern_page = page.time_sel
       -- local pattern = g.device ~= nil and grid_pat[pattern_page] or midi_pat[pattern_page]
-      local pattern = get_grid_connected() and grid_pat[pattern_page] or midi_pat[pattern_page]
+      local pattern
+
+      if get_grid_connected() or osc_communication then
+        pattern = grid_pat[pattern_page]
+      else
+        pattern =  midi_pat[pattern_page]
+      end
       
       if pattern_page < 4 then
         if page_line[pattern_page] == 7 then

--- a/lib/main_menu.lua
+++ b/lib/main_menu.lua
@@ -1062,7 +1062,12 @@ function main_menu.init()
     for i = 1,3 do
       screen.level(page_line == i and 15 or 3)
       -- local pattern = g.device ~= nil and grid_pat[i] or midi_pat[i]
-      local pattern = get_grid_connected() and grid_pat[i] or midi_pat[i]
+      local pattern
+      if get_grid_connected() or osc_communication then
+        pattern = grid_pat[i]
+      else
+        pattern =  midi_pat[i]
+      end
       screen.move(10+(20*(i-1)),25)
       screen.text("P"..i)
       screen.move(5+(20*(i-1)),25)
@@ -1075,8 +1080,12 @@ function main_menu.init()
     end
     
     if page.time_sel < 4 then
-      -- local pattern = g.device ~= nil and grid_pat[page_line] or midi_pat[page_line]
-      local pattern = get_grid_connected() and grid_pat[page_line] or midi_pat[page_line]
+      local pattern
+      if get_grid_connected() or osc_communication then
+        pattern = grid_pat[page_line]
+      else
+        pattern =  midi_pat[page_line]
+      end
       if pattern.sync_hold ~= nil and pattern.sync_hold then
         local show_me_beats = clock.get_beats() % 4
         local show_me_frac = math.fmod(clock.get_beats(),1)

--- a/lib/start_up.lua
+++ b/lib/start_up.lua
@@ -567,7 +567,7 @@ function start_up.init()
       action=function()
         if all_loaded then
           -- if g.device ~= nil then
-          if get_grid_connected() then
+          if get_grid_connected() or osc_communication then
             random_grid_pat(i,3)
           else
             random_midi_pat(i)
@@ -584,7 +584,7 @@ function start_up.init()
         if all_loaded then
           if x == 1 then
             -- if g.device ~= nil then
-            if get_grid_connected() then
+            if get_grid_connected() or osc_communication then
               random_grid_pat(id,2)
             else
               shuffle_midi_pat(id)


### PR DESCRIPTION
## fixed

- filter value changes were hitting softcut 16 times per pad, instead of simply sending values to the 16 pad variables and hitting softcut once. this fix vastly improves CPU utilization when heavily modulating the filters with lfos, `rnd`, or arc patterns.
- OSC communication regression has been corrected + some of the functions have been streamlined to mimic grid more closely on the backend (eg. hitting `rand pat` on TouchOSC will now affect the timing screen the same way a random grid pattern would)